### PR TITLE
fix: TS types w/ `NodeNext` module resolution

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export { default as prerender } from './prerender';
-export * from './router';
-export { default as lazy, ErrorBoundary } from './lazy';
-export { default as hydrate } from './hydrate';
+export { default as prerender } from './prerender.js';
+export * from './router.js';
+export { default as lazy, ErrorBoundary } from './lazy.js';
+export { default as hydrate } from './hydrate.js';


### PR DESCRIPTION
https://arethetypeswrong.github.io/?p=preact-iso%402.3.1

Importing from the bare module results in broken types with the `NodeNext` module resolution, as TS expects `.js` extensions to refer to the other `.d.ts` types.