### PR TITLE
fix: Mark rts as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
 		"preact": ">=10",
 		"preact-render-to-string": ">=5"
 	},
+	"peerDependenciesMeta": {
+		"preact-render-to-string": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"htm": "^3.0.4",
 		"jest": "26.6.3",


### PR DESCRIPTION
RTS is only used for the prerender export so it should be optional.