### PR TITLE
feat: Support for the replace parameter in useLocation().route

### DIFF
--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -13,7 +13,7 @@ interface LocationHook {
 	url: string;
 	path: string;
 	query: Record<string, string>;
-	route: (url: string) => void;
+	route: (url: string, replace?: boolean) => void;
 }
 export const useLocation: () => LocationHook;
 

--- a/src/router.js
+++ b/src/router.js
@@ -25,6 +25,9 @@ const UPDATE = (state, url) => {
 		url = link.href.replace(location.origin, '');
 	} else if (typeof url === 'string') {
 		push = true;
+	} else if (url && url.url) {
+		push = !url.replace;
+		url = url.url;
 	} else {
 		url = location.pathname + location.search;
 	}
@@ -69,7 +72,13 @@ export function LocationProvider(props) {
 		const u = new URL(url, location.origin);
 		const path = u.pathname.replace(/(.)\/$/g, '$1');
 		// @ts-ignore-next
-		return { url, path, query: Object.fromEntries(u.searchParams), route, wasPush };
+		return {
+			url,
+			path,
+			query: Object.fromEntries(u.searchParams),
+			route: (url, replace) => route({ url, replace }),
+			wasPush
+		};
 	}, [url]);
 
 	useLayoutEffect(() => {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -504,4 +504,32 @@ describe('Router', () => {
 		await sleep(20);
 		expect(params).toMatchObject({ id: 'bar' });
 	});
+
+	it('should replace the current URL', async () => {
+		const pushState = jest.spyOn(history, 'pushState');
+		const replaceState = jest.spyOn(history, 'replaceState');
+		let loc;
+
+		render(
+			html`
+				<${LocationProvider}>
+					<${Router}>
+						<${Route} path="/foo" component=${() => null} />
+					<//>
+					<${() => {
+						loc = useLocation();
+					}} />
+				<//>
+			`,
+			scratch
+		);
+
+		await sleep(20);
+		loc.route("/foo", true);
+		expect(pushState).not.toHaveBeenCalled();
+		expect(replaceState).toHaveBeenCalledWith(null, "", "/foo");
+
+		pushState.mockRestore();
+		replaceState.mockRestore();
+	});
 });


### PR DESCRIPTION
Implementation https://github.com/preactjs/preact-iso/issues/6#issuecomment-1929966569

```ts
const loc = useLocation()

loc.route('/', true)
````

---

Strange, I didn't find the formatting configuration, maybe [this](https://github.com/preactjs/preact/blob/a3f7c33693f18d8d51e18478a9cc0d02f74a11d1/package.json#L191-L195) is used?
