### PR TITLE
fix: RTS peer dep w/ Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,6 @@
 		"preact": ">=10",
 		"preact-render-to-string": ">=6.4.0"
 	},
-	"peerDependenciesMeta": {
-		"preact-render-to-string": {
-			"optional": true
-		}
-	},
 	"devDependencies": {
 		"htm": "^3.1.1",
 		"jest": "^29.7.0",

--- a/src/prerender.js
+++ b/src/prerender.js
@@ -1,6 +1,6 @@
 import { h, options, cloneElement } from 'preact';
+import { renderToStringAsync } from 'preact-render-to-string';
 
-let renderToStringAsync;
 let vnodeHook;
 
 const old = options.vnode;
@@ -15,7 +15,6 @@ options.vnode = vnode => {
  * @param {object} [options.props] Additional props to merge into the root JSX element
  */
 export default async function prerender(vnode, options) {
-    if (!renderToStringAsync) ({ renderToStringAsync } = await import('preact-render-to-string'));
 	options = options || {};
 
 	const props = options.props;

--- a/src/prerender.js
+++ b/src/prerender.js
@@ -1,6 +1,6 @@
 import { h, options, cloneElement } from 'preact';
-import { renderToStringAsync } from 'preact-render-to-string';
 
+let renderToStringAsync;
 let vnodeHook;
 
 const old = options.vnode;
@@ -15,6 +15,7 @@ options.vnode = vnode => {
  * @param {object} [options.props] Additional props to merge into the root JSX element
  */
 export default async function prerender(vnode, options) {
+    if (!renderToStringAsync) ({ renderToStringAsync } = await import('preact-render-to-string'));
 	options = options || {};
 
 	const props = options.props;


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preset-vite/issues/117

Vite's pretty weird here; when RTS isn't installed...
  - and the default export is used, it'll have no problem
  - and a wildcard import is used, it'll emit a warning
  - and a named import is used, it'll fall right over and fail to build (as the linked issue shows)

Alternatively, maybe it's worth reverting making RTS an optional peer dep altogether as there's also [this funky issue](https://github.com/vitejs/vite/discussions/15725)

Edit: Worth looking at in the next major, maybe keep `/prerender` as the only subpath export. I don't want to break anything now though.