### PR TITLE
fix: Ensure `loadEnd` is called even without route navigation

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -186,12 +186,13 @@ export function Router(props) {
 		// The route is loaded and rendered.
 		if (prevRoute.current !== path) {
 			if (wasPush) scrollTo(0, 0);
-			if (props.onLoadEnd && isLoading.current) props.onLoadEnd(url);
 			if (props.onRouteChange) props.onRouteChange(url);
 
-			isLoading.current = false;
 			prevRoute.current = path;
 		}
+
+		if (props.onLoadEnd && isLoading.current) props.onLoadEnd(url);
+		isLoading.current = false;
 	}, [path, wasPush, c]);
 
 	// Note: curChildren MUST render first in order to set didSuspend & prev.

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -417,7 +417,6 @@ describe('Router', () => {
 			<p>hello</p>
 		`;
 		const A = jest.fn(groggy(() => route('A'), 1));
-		const loadStart = jest.fn();
 		const loadEnd = jest.fn();
 		let set;
 
@@ -428,7 +427,6 @@ describe('Router', () => {
 				<${ErrorBoundary}>
 					<${LocationProvider}>
 						<${Router}
-							onLoadStart=${loadStart}
 							onLoadEnd=${loadEnd}
 						>
 							<${A} path="/" />
@@ -444,14 +442,11 @@ describe('Router', () => {
 
 		await sleep(10);
 
-		A.mockClear();
-		loadStart.mockClear();
 		loadEnd.mockClear();
 
 		set('2');
 		await sleep(1);
 
-		expect(loadStart).not.toHaveBeenCalled();
 		expect(loadEnd).not.toHaveBeenCalled();
 	});
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -306,6 +306,155 @@ describe('Router', () => {
 		expect(A).toHaveBeenCalledWith({ path: '/', query: {}, params: {}, rest: '' }, expect.anything());
 	});
 
+	it('should support onLoadStart/onLoadEnd/onRouteChange w/out navigation', async () => {
+		const route = name => html`
+			<h1>${name}</h1>
+			<p>hello</p>
+		`;
+		const A = jest.fn(groggy(() => route('A'), 1));
+		const loadStart = jest.fn();
+		const loadEnd = jest.fn();
+		const routeChange = jest.fn();
+		render(
+			html`
+				<${ErrorBoundary}>
+					<${LocationProvider}>
+						<${Router}
+							onLoadStart=${loadStart}
+							onLoadEnd=${loadEnd}
+							onRouteChange=${routeChange}
+						>
+							<${A} path="/" />
+						<//>
+					<//>
+				<//>
+			`,
+			scratch
+		);
+
+		expect(scratch).toHaveProperty('innerHTML', '');
+		expect(A).toHaveBeenCalledWith({ path: '/', query: {}, params: {}, rest: '' }, expect.anything());
+		expect(loadStart).toHaveBeenCalledWith('/');
+		expect(loadEnd).not.toHaveBeenCalled();
+		expect(routeChange).not.toHaveBeenCalled();
+
+		A.mockClear();
+		loadStart.mockClear();
+		loadEnd.mockClear();
+		routeChange.mockClear();
+		await sleep(10);
+
+		expect(scratch).toHaveProperty('innerHTML', '<h1>A</h1><p>hello</p>');
+		expect(A).toHaveBeenCalledWith({ path: '/', query: {}, params: {}, rest: '' }, expect.anything());
+		expect(loadStart).not.toHaveBeenCalled();
+		expect(loadEnd).toHaveBeenCalledWith('/');
+		expect(routeChange).not.toHaveBeenCalled();
+	});
+
+	it('should support onLoadStart/onLoadEnd/onRouteChange w/ navigation', async () => {
+		const route = name => html`
+			<h1>${name}</h1>
+			<p>hello</p>
+		`;
+		const A = jest.fn(groggy(() => route('A'), 1));
+		const B = jest.fn(groggy(() => route('B'), 1));
+		const loadStart = jest.fn();
+		const loadEnd = jest.fn();
+		const routeChange = jest.fn();
+		let loc;
+		render(
+			html`
+				<${ErrorBoundary}>
+					<${LocationProvider}>
+						<${Router}
+							onLoadStart=${loadStart}
+							onLoadEnd=${loadEnd}
+							onRouteChange=${routeChange}
+						>
+							<${A} path="/" />
+							<${B} path="/b" />
+						<//>
+						<${() => {
+							loc = useLocation();
+						}} />
+					<//>
+				<//>
+			`,
+			scratch
+		);
+
+		await sleep(10);
+
+		A.mockClear();
+		loadStart.mockClear();
+		loadEnd.mockClear();
+		routeChange.mockClear();
+
+		loc.route('/b');
+
+		await sleep(1);
+
+		expect(loadStart).toHaveBeenCalledWith('/b');
+		expect(loadEnd).not.toHaveBeenCalled();
+		expect(routeChange).not.toHaveBeenCalled();
+
+		A.mockClear();
+		loadStart.mockClear();
+		loadEnd.mockClear();
+		routeChange.mockClear();
+
+		await sleep(10);
+
+		expect(scratch).toHaveProperty('innerHTML', '<h1>B</h1><p>hello</p>');
+		expect(loadStart).not.toHaveBeenCalled();
+		expect(loadEnd).toHaveBeenCalledWith('/b');
+		expect(routeChange).toHaveBeenCalledWith('/b');
+	});
+
+	it('should only call onLoadEnd once upon promise flush', async () => {
+		const route = name => html`
+			<h1>${name}</h1>
+			<p>hello</p>
+		`;
+		const A = jest.fn(groggy(() => route('A'), 1));
+		const loadStart = jest.fn();
+		const loadEnd = jest.fn();
+		let set;
+
+		const App = () => {
+			const [test, setTest] = useState('1');
+			set = setTest;
+			return html`
+				<${ErrorBoundary}>
+					<${LocationProvider}>
+						<${Router}
+							onLoadStart=${loadStart}
+							onLoadEnd=${loadEnd}
+						>
+							<${A} path="/" />
+						<//>
+					<//>
+				<//>
+			`;
+		}
+		render(
+			html`<${App} />`,
+			scratch
+		);
+
+		await sleep(10);
+
+		A.mockClear();
+		loadStart.mockClear();
+		loadEnd.mockClear();
+
+		set('2');
+		await sleep(1);
+
+		expect(loadStart).not.toHaveBeenCalled();
+		expect(loadEnd).not.toHaveBeenCalled();
+	});
+
 	describe('intercepted VS external links', () => {
 		const shouldIntercept = [null, '', '_self', 'self', '_SELF'];
 		const shouldNavigate = ['_top', '_parent', '_blank', 'custom', '_BLANK'];


### PR DESCRIPTION
The current setup for `onLoadEnd` is problematic as we also need to be able to trigger it without route change, such as a page load/refresh. [preact-www](https://github.com/preactjs/preact-www/blob/89f74cb4a416b2679d7ed80fce185f2e614bf02c/src/components/routes.jsx#L13-L19) displays this issue and is locked to an older version because of this, as the loading bar will run from initial page load until the user navigates elsewhere.

This adds tests for `onLoadStart`/`onLoadEnd`/`onRouteChange` for page load & navigation, as well as a test to ensure we haven't regressed to calling `onLoadEnd` on every render, which was [the reason](https://github.com/preactjs/wmr/issues/836) for this setup.