### PR TITLE
fix: Ensure same-component routes are rerendered rather than swapped

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -138,7 +138,7 @@ export function Router(props) {
 			if (this.__v && this.__v.__k) this.__v.__k.reverse();
 			count.current++;
 			routeChanged.current = true;
-		}
+		} else routeChanged.current = false;
 	}, [url]);
 
 	const isHydratingSuspense = cur.current && cur.current.__u & MODE_HYDRATE && cur.current.__u & MODE_SUSPENDED;


### PR DESCRIPTION
Avoids swapping out component if the route hasn't changed. I remember seeing Jason ran into this on [Mastodawn](https://github.com/developit/mastodawn/blob/main/patches/preact-iso%2B2.3.1.patch), modified his implementation a bit for here.

I'm not 100% sure of this implementation, but the issue I'm looking to fix is that same-component navigations end up dropping the previous for the new which can be pretty wasteful & slow. _I believe_ diffing should win out for same-component routes more often than not, which is the main change here.

This is especially bad on the Preact docs site, where navigating via the sidebar replaces the entire page (minus the header) as we have a rather "fat" routing setup. 