### PR TITLE
Match base route on wildcard

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -46,8 +46,8 @@ export const exec = (url, route, matches) => {
 		// segment match:
 		if (!m && param == val) continue;
 		// /foo/* match
-		if (!m && val && flag == '*') {
-			matches.rest = '/' + url.slice(i).map(decodeURIComponent).join('/');
+		if (!m && flag == '*') {
+			if (val) matches.rest = '/' + url.slice(i).map(decodeURIComponent).join('/');
 			break;
 		}
 		// segment mismatch / missing required field:

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -22,6 +22,14 @@ describe('match', () => {
 		expect(inaccurateResult).toEqual(undefined);
 	});
 
+	it('Param route - no rest', () => {
+		const accurateResult = execPath('/user', '/user/*');
+		expect(accurateResult).toEqual({ path: '/user', params: {}, query: {} });
+
+		const inaccurateResult = execPath('/', '/user/*');
+		expect(inaccurateResult).toEqual(undefined);
+	});
+
 	it('Param rest segment', () => {
 		const accurateResult = execPath('/user/foo', '/user/*');
 		expect(accurateResult).toEqual({ path: '/user/foo', params: {}, query: {}, rest: '/foo' });


### PR DESCRIPTION
Fixes the behavior that a wildcard parameter would not match the base path.

Path `/profile` is currently not matched by:

```Javascript
<Router>
    <Profile path="/profile/*" />
</Router>
```