### PR TITLE
feat: Add `location` stub utility

### DIFF
--- a/src/prerender.d.ts
+++ b/src/prerender.d.ts
@@ -13,3 +13,5 @@ export default function prerender(
 	vnode: VNode,
 	options?: PrerenderOptions
 ): Promise<PrerenderResult>;
+
+export function locationStub(path: string): void;

--- a/src/prerender.js
+++ b/src/prerender.js
@@ -47,10 +47,13 @@ export default async function prerender(vnode, options) {
  * @param {string} path - current URL path
  */
 export function locationStub(path) {
+	globalThis.location = {};
 	const u = new URL(path, 'http://localhost');
 	for (const i in u) {
 		try {
-			globalThis.location[i] = String(u[i]);
+            globalThis.location[i] = /to[A-Z]/.test(i)
+                ? u[i].bind(u)
+                : String(u[i]);
 		} catch {}
 	}
 }

--- a/src/prerender.js
+++ b/src/prerender.js
@@ -40,3 +40,17 @@ export default async function prerender(vnode, options) {
 		vnodeHook = null;
 	}
 }
+
+/**
+ * Update `location` to current URL so routers can use things like `location.pathname`
+ *
+ * @param {string} path - current URL path
+ */
+export function locationStub(path) {
+	const u = new URL(path, 'http://localhost');
+	for (const i in u) {
+		try {
+			globalThis.location[i] = String(u[i]);
+		} catch {}
+	}
+}

--- a/test/location-stub.test.js
+++ b/test/location-stub.test.js
@@ -1,0 +1,36 @@
+import { describe, it, beforeEach, expect } from '@jest/globals';
+import { locationStub } from '../src/prerender.js';
+
+describe('location-stub', () => {
+	beforeEach(() => {
+		if (globalThis.location) {
+			delete globalThis.location;
+		}
+	});
+
+	it('Contains all Location instance properties', () => {
+		locationStub('/foo/bar?baz=qux#quux');
+
+		[
+			// 'ancestorOrigins', // Not supported by FireFox and sees little use, but we could add an empty val if it's needed
+			'hash',
+			'host',
+			'hostname',
+			'href',
+			'origin',
+			'pathname',
+			'port',
+			'protocol',
+			'search',
+		].forEach(key => {
+			expect(globalThis.location).toHaveProperty(key);
+		});
+	});
+
+	// Do we need to support `assign`, `reload`, and/or `replace`?
+	it('Support bound methods', () => {
+		locationStub('/foo/bar?baz=qux#quux');
+
+		expect(globalThis.location.toString()).toBe('http://localhost/foo/bar?baz=qux#quux');
+	});
+});


### PR DESCRIPTION
While a user can pass a `url` prop to `LocationProvider` (our types don't support this though), without this location stub, the router will not work during SSR as it unconditionally tries to access `location.origin`:

https://github.com/preactjs/preact-iso/blob/2398d3b824af7ff445bf9337082ad9ed523415b5/src/router.js#L72

I'm generally in favor of pushing the `location` stub anyhow, it's far more robust in allowing client-side libs to work properly, hence, making it available here for any using the router (but using their own SSR impl). I don't think passing the URL prop to components is a great pattern that we should fix or support really, but that's just me.