### PR TITLE
test: Reduce wtr timeout limit

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -2,6 +2,7 @@ import { esbuildPlugin } from "@web/dev-server-esbuild";
 
 export default {
 	nodeResolve: true,
+	testsFinishTimeout: 30000,
 	plugins: [
 		esbuildPlugin({
 			jsx: true,


### PR DESCRIPTION
https://github.com/preactjs/preact-iso/pull/37#discussion_r1730313791 -- failures aren't picked up correctly at the moment, forcing users to wait for timeouts. Default is `120000` (2 minutes) which is excessive for our suite as it should take less than ~5s.