### PR TITLE
feat: Adds `scope` prop to `LocationProvider`, limiting link intercepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ export async function prerender(data) {
 
 A context provider that provides the current location to its children. This is required for the router to function.
 
+Props:
+
+-   `limit?: string | RegExp` - Sets a limit on the paths that the router will handle (intercept). If a path does not match the limit, either by starting with the provided string or matching the RegExp, the router will ignore it and default browser navigation will apply.
+
 Typically, you would wrap your entire app in this provider:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A context provider that provides the current location to its children. This is r
 
 Props:
 
--   `limit?: string | RegExp` - Sets a limit on the paths that the router will handle (intercept). If a path does not match the limit, either by starting with the provided string or matching the RegExp, the router will ignore it and default browser navigation will apply.
+-   `scope?: string | RegExp` - Sets a scope for the paths that the router will handle (intercept). If a path does not match the scope, either by starting with the provided string or matching the RegExp, the router will ignore it and default browser navigation will apply.
 
 Typically, you would wrap your entire app in this provider:
 
@@ -92,7 +92,7 @@ Typically, you would wrap your entire app in this provider:
 import { LocationProvider } from 'preact-iso';
 
 const App = () => (
-    <LocationProvider>
+    <LocationProvider scope="/app">
         {/* Your app here */}
     </LocationProvider>
 );

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -1,7 +1,7 @@
 import { AnyComponent, FunctionComponent, VNode } from 'preact';
 
 export function LocationProvider(props: {
-	limit?: string | RegExp;
+	scope?: string | RegExp;
 	children?: VNode[];
 }): VNode;
 

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -1,7 +1,6 @@
 import { AnyComponent, FunctionComponent, VNode } from 'preact';
 
 export function LocationProvider(props: {
-	url?: string;
 	limit?: string | RegExp;
 	children?: VNode[];
 }): VNode;

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -1,8 +1,8 @@
-import { AnyComponent, FunctionComponent, VNode } from 'preact';
+import { AnyComponent, ComponentChildren, FunctionComponent, VNode } from 'preact';
 
 export function LocationProvider(props: {
 	scope?: string | RegExp;
-	children?: VNode[];
+	children?: ComponentChildren;
 }): VNode;
 
 type NestedArray<T> = Array<T | NestedArray<T>>;

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -1,6 +1,10 @@
 import { AnyComponent, FunctionComponent, VNode } from 'preact';
 
-export const LocationProvider: FunctionComponent;
+export function LocationProvider(props: {
+	url?: string;
+	limit?: string | RegExp;
+	children?: VNode[];
+}): VNode;
 
 type NestedArray<T> = Array<T | NestedArray<T>>;
 

--- a/src/router.js
+++ b/src/router.js
@@ -21,7 +21,7 @@ const UPDATE = (state, url) => {
 		if (
 			!link ||
 			link.origin != location.origin ||
-			/^#/.test(link.getAttribute('href')) ||
+			/^#/.test(href) ||
 			!/^(_?self)?$/i.test(link.target) ||
 			limit && (typeof limit == 'string'
 				? !href.startsWith(limit)

--- a/src/router.js
+++ b/src/router.js
@@ -7,7 +7,7 @@ import { useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'preact
  * @typedef {import('./internal.d.ts').VNode} VNode
  */
 
-let push, limit;
+let push, scope;
 const UPDATE = (state, url) => {
 	push = undefined;
 	if (url && url.type === 'click') {
@@ -23,9 +23,9 @@ const UPDATE = (state, url) => {
 			link.origin != location.origin ||
 			/^#/.test(href) ||
 			!/^(_?self)?$/i.test(link.target) ||
-			limit && (typeof limit == 'string'
-				? !href.startsWith(limit)
-				: !limit.test(href)
+			scope && (typeof scope == 'string'
+				? !href.startsWith(scope)
+				: !scope.test(href)
 			)
 		) {
 			return state;
@@ -75,9 +75,13 @@ export const exec = (url, route, matches) => {
 	return matches;
 };
 
+/**
+ * @type {import('./router.d.ts').LocationProvider}
+ */
 export function LocationProvider(props) {
+	// @ts-expect-error - props.url is not implemented correctly & will be removed in the future
 	const [url, route] = useReducer(UPDATE, props.url || location.pathname + location.search);
-	if (props.limit) limit = props.limit;
+	if (props.scope) scope = props.scope;
 	const wasPush = push === true;
 
 	const value = useMemo(() => {

--- a/src/router.js
+++ b/src/router.js
@@ -7,7 +7,7 @@ import { useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'preact
  * @typedef {import('./internal.d.ts').VNode} VNode
  */
 
-let push;
+let push, limit;
 const UPDATE = (state, url) => {
 	push = undefined;
 	if (url && url.type === 'click') {
@@ -16,12 +16,17 @@ const UPDATE = (state, url) => {
 			return state;
 		}
 
-		const link = url.target.closest('a[href]');
+		const link = url.target.closest('a[href]'),
+			href = link.getAttribute('href');
 		if (
 			!link ||
 			link.origin != location.origin ||
 			/^#/.test(link.getAttribute('href')) ||
-			!/^(_?self)?$/i.test(link.target)
+			!/^(_?self)?$/i.test(link.target) ||
+			limit && (typeof limit == 'string'
+				? !href.startsWith(limit)
+				: !limit.test(href)
+			)
 		) {
 			return state;
 		}
@@ -72,6 +77,7 @@ export const exec = (url, route, matches) => {
 
 export function LocationProvider(props) {
 	const [url, route] = useReducer(UPDATE, props.url || location.pathname + location.search);
+	if (props.limit) limit = props.limit;
 	const wasPush = push === true;
 
 	const value = useMemo(() => {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -588,15 +588,13 @@ describe('Router', () => {
 
 		const clickHandler = sinon.fake(e => e.preventDefault());
 
-		const Route = sinon.fake(
-			() => (
-				<div>
-					<a href="/app">Internal Link</a>
-					<a href="/app/deeper">Internal Deeper Link</a>
-					<a href="/site">External Link</a>
-					<a href="/site/deeper">External Deeper Link</a>
-				</div>
-			)
+		const Links = () => (
+			<>
+				<a href="/app">Internal Link</a>
+				<a href="/app/deeper">Internal Deeper Link</a>
+				<a href="/site">External Link</a>
+				<a href="/site/deeper">External Deeper Link</a>
+			</>
 		);
 
 		let pushState;
@@ -612,7 +610,6 @@ describe('Router', () => {
 		});
 
 		beforeEach(async () => {
-			Route.resetHistory();
 			clickHandler.resetHistory();
 			pushState.resetHistory();
 		});
@@ -620,14 +617,11 @@ describe('Router', () => {
 		it('should intercept clicks on links matching the `scope` props (string)', async () => {
 			render(
 				<LocationProvider scope="/app">
-					<Router>
-						<Route default />
-					</Router>
+					<Links />
 					<ShallowLocation />
 				</LocationProvider>,
 				scratch
 			);
-			Route.resetHistory();
 			await sleep(10);
 
 			for (const url of shouldIntercept) {
@@ -635,11 +629,9 @@ describe('Router', () => {
 				el.click();
 				await sleep(1);
 				expect(loc).to.deep.include({ url });
-				expect(Route).to.have.been.calledOnce;
 				expect(pushState).to.have.been.calledWith(null, '', url);
 				expect(clickHandler).to.have.been.called;
 
-				Route.resetHistory();
 				pushState.resetHistory();
 				clickHandler.resetHistory();
 			}
@@ -648,25 +640,20 @@ describe('Router', () => {
 		it('should allow default browser navigation for links not matching the `limit` props (string)', async () => {
 			render(
 				<LocationProvider scope="app">
-					<Router>
-						<Route default />
-					</Router>
+					<Links />
 					<ShallowLocation />
 				</LocationProvider>,
 				scratch
 			);
-			Route.resetHistory();
 			await sleep(10);
 
 			for (const url of shouldNavigate) {
 				const el = scratch.querySelector(`a[href="${url}"]`);
 				el.click();
 				await sleep(1);
-				expect(Route).not.to.have.been.called;
 				expect(pushState).not.to.have.been.called;
 				expect(clickHandler).to.have.been.called;
 
-				Route.resetHistory();
 				pushState.resetHistory();
 				clickHandler.resetHistory();
 			}
@@ -675,14 +662,11 @@ describe('Router', () => {
 		it('should intercept clicks on links matching the `limit` props (regex)', async () => {
 			render(
 				<LocationProvider scope={/^\/app/}>
-					<Router>
-						<Route default />
-					</Router>
+					<Links />
 					<ShallowLocation />
 				</LocationProvider>,
 				scratch
 			);
-			Route.resetHistory();
 			await sleep(10);
 
 			for (const url of shouldIntercept) {
@@ -690,11 +674,9 @@ describe('Router', () => {
 				el.click();
 				await sleep(1);
 				expect(loc).to.deep.include({ url });
-				expect(Route).to.have.been.calledOnce;
 				expect(pushState).to.have.been.calledWith(null, '', url);
 				expect(clickHandler).to.have.been.called;
 
-				Route.resetHistory();
 				pushState.resetHistory();
 				clickHandler.resetHistory();
 			}
@@ -703,25 +685,20 @@ describe('Router', () => {
 		it('should allow default browser navigation for links not matching the `limit` props (regex)', async () => {
 			render(
 				<LocationProvider scope={/^\/app/}>
-					<Router>
-						<Route default />
-					</Router>
+					<Links />
 					<ShallowLocation />
 				</LocationProvider>,
 				scratch
 			);
-			Route.resetHistory();
 			await sleep(10);
 
 			for (const url of shouldNavigate) {
 				const el = scratch.querySelector(`a[href="${url}"]`);
 				el.click();
 				await sleep(1);
-				expect(Route).not.to.have.been.called;
 				expect(pushState).not.to.have.been.called;
 				expect(clickHandler).to.have.been.called;
 
-				Route.resetHistory();
 				pushState.resetHistory();
 				clickHandler.resetHistory();
 			}

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -582,7 +582,7 @@ describe('Router', () => {
 		}
 	});
 
-	describe('intercepted VS external links with `limit`', () => {
+	describe('intercepted VS external links with `scope`', () => {
 		const shouldIntercept = ['/app', '/app/deeper'];
 		const shouldNavigate = ['/site', '/site/deeper'];
 
@@ -617,9 +617,9 @@ describe('Router', () => {
 			pushState.resetHistory();
 		});
 
-		it('should intercept clicks on links matching the `limit` props (string)', async () => {
+		it('should intercept clicks on links matching the `scope` props (string)', async () => {
 			render(
-				<LocationProvider limit="/app">
+				<LocationProvider scope="/app">
 					<Router>
 						<Route default />
 					</Router>
@@ -647,7 +647,7 @@ describe('Router', () => {
 
 		it('should allow default browser navigation for links not matching the `limit` props (string)', async () => {
 			render(
-				<LocationProvider limit="app">
+				<LocationProvider scope="app">
 					<Router>
 						<Route default />
 					</Router>
@@ -674,7 +674,7 @@ describe('Router', () => {
 
 		it('should intercept clicks on links matching the `limit` props (regex)', async () => {
 			render(
-				<LocationProvider limit={/^\/app/}>
+				<LocationProvider scope={/^\/app/}>
 					<Router>
 						<Route default />
 					</Router>
@@ -702,7 +702,7 @@ describe('Router', () => {
 
 		it('should allow default browser navigation for links not matching the `limit` props (regex)', async () => {
 			render(
-				<LocationProvider limit={/^\/app/}>
+				<LocationProvider scope={/^\/app/}>
 					<Router>
 						<Route default />
 					</Router>


### PR DESCRIPTION
Closes #34

Allows users to opt-out of link interception, setting a string & regexp scope that intercepts should be limited to, e.g., `<LocationProvider scope="/app">` will ignore clicks to `/site`.