### PR TITLE
fix: Wildcard splat/rest param matches should return `undefined` instead of empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,21 @@ Paths are matched using a simple string matching algorithm. The following featur
 -   `:param` - Matches any URL segment, binding the value to the label (can later extract this value from `useRoute()`)
     -   `/profile/:id` will match `/profile/123` and `/profile/abc`
     -   `/profile/:id?` will match `/profile` and `/profile/123`
+    -   `/profile/:id*` will match `/profile`, `/profile/123`, and `/profile/123/abc`
+    -   `/profile/:id+` will match `/profile/123`, `/profile/123/abc`
 -   `*` - Matches one or more URL segments
     -   `/profile/*` will match `/profile/123`, `/profile/123/abc`, etc.
 
 These can then be composed to create more complex routes:
 
 -   `/profile/:id/*` will match `/profile/123/abc`, `/profile/123/abc/def`, etc.
+
+The difference between `/:id*` and `/:id/*` is that in the former, the `id` param will include the entire path after it, while in the latter, the `id` is just the single path segment.
+
+-  `/profile/:id*`, with `/profile/123/abc`
+    -  `id` is `123/abc`
+-  `/profile/:id/*`, with `/profile/123/abc`
+    - `id` is `123`
 
 ### `useLocation`
 

--- a/src/router.js
+++ b/src/router.js
@@ -65,7 +65,7 @@ export const exec = (url, route, matches) => {
 		if (!m || (!val && flag != '?' && flag != '*')) return;
 		rest = flag == '+' || flag == '*';
 		// rest (+/*) match:
-		if (rest) val = url.slice(i).map(decodeURIComponent).join('/');
+		if (rest) val = url.slice(i).map(decodeURIComponent).join('/') || undefined;
 		// normal/optional field:
 		else if (val) val = decodeURIComponent(val);
 		matches.params[param] = val;

--- a/test/node/router-match.test.js
+++ b/test/node/router-match.test.js
@@ -58,10 +58,26 @@ test('Optional param route', () => {
 });
 
 test('Optional rest param route "/:x*"', () => {
-	const accurateResult = execPath('/user', '/user/:id?');
-	assert.equal(accurateResult, { path: '/user', params: { id: undefined }, id: undefined, query: {} });
+	const matchedResult = execPath('/user', '/user/:id*');
+	assert.equal(matchedResult, { path: '/user', params: { id: undefined }, id: undefined, query: {} });
 
-	const inaccurateResult = execPath('/', '/user/:id?');
+	const matchedResultWithSlash = execPath('/user/foo/bar', '/user/:id*');
+	assert.equal(matchedResultWithSlash, {
+		path: '/user/foo/bar',
+		params: { id: 'foo/bar' },
+		id: 'foo/bar',
+		query: {}
+	});
+
+	const emptyResult = execPath('/user', '/user/:id*');
+	assert.equal(emptyResult, {
+		path: '/user',
+		params: { id: undefined },
+		id: undefined,
+		query: {}
+	});
+
+	const inaccurateResult = execPath('/', '/user/:id*');
 	assert.equal(inaccurateResult, undefined);
 });
 


### PR DESCRIPTION
Whilst https://github.com/preactjs/wmr/commit/d503514743da838f086d5760fbc62144f93fc774 added a test entry for `/:x*` paths, unfortunately it copied the test block for optional params (`/:x?`) and only updated the test name -- the actual test cases were duplicates that didn't ensure what they were meant to.

This PR therefore corrects that and adds proper tests, but also ensures optional params become `undefined`, rather than empty strings, to match the behavior of `/:x?` in the case of the param not being set. I'd call this non-breaking as the previous behavior isn't correct or consistent and any falsy check will still fail all the same.