### PR TITLE
feat: Switch routable props type over to an xor

### DIFF
--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -30,8 +30,8 @@ interface RouteHook {
 export const useRoute: () => RouteHook;
 
 type RoutableProps =
-	| { path: string; default?: never; }
-	| { path?: never; default: boolean; }
+	| { path: string; default?: false; }
+	| { path?: never; default: true; }
 
 export type RouteProps<Props> = RoutableProps & { component: AnyComponent<Props> };
 

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -29,14 +29,11 @@ interface RouteHook {
 }
 export const useRoute: () => RouteHook;
 
-interface RoutableProps {
-	path?: string;
-	default?: boolean;
-}
+type RoutableProps =
+	| { path: string; default?: never; }
+	| { path?: never; default: boolean; }
 
-export interface RouteProps<Props> extends RoutableProps {
-	component: AnyComponent<Props>;
-}
+export type RouteProps<Props> = RoutableProps & { component: AnyComponent<Props> };
 
 export function Route<Props>(props: RouteProps<Props> & Partial<Props>): VNode;
 


### PR DESCRIPTION
This change ensures the user sets either `path` or `default` for a route, but never both.

Previously, the types erroneously allowed you to set neither &/or both; setting neither made it a dead route, never to be used, and setting both is simply redundant.

---

TS's error message isn't great, if the user sets neither, they'll be met with the following which only mentions the latter half of the XOR:

```
Type '{ component: () => Element; }' is not assignable to type 'IntrinsicAttributes & (RouteProps<{ component: () => Element; }> & Partial<{ component: () => Element; }>)'.
  Type '{ component: () => Element; }' is not assignable to type 'IntrinsicAttributes & { path?: never; default: boolean; } & { component: AnyComponent<{ component: () => Element; }>; } & Partial<{ component: () => Element; }>'.
    Property 'default' is missing in type '{ component: () => Element; }' but required in type '{ path?: never; default: boolean; }'.

Related information:

  * router.d.ts#34,20: 'default' is declared here.

 (tsserver 2322)
```

Don't think we can do anything about this though.