### PR TITLE
fix: Hydrate types

### DIFF
--- a/src/hydrate.d.ts
+++ b/src/hydrate.d.ts
@@ -1,3 +1,3 @@
-import { ComponentChild } from 'preact';
+import { hydrate } from 'preact';
 
-export default function hydrate(jsx: ComponentChild, parent?: Element | Document | ShadowRoot | DocumentFragment): void;
+export default hydrate;

--- a/src/hydrate.js
+++ b/src/hydrate.js
@@ -2,7 +2,7 @@ import { render, hydrate as hydrativeRender } from 'preact';
 
 let initialized;
 
-/** @type {typeof render} */
+/** @type {typeof hydrativeRender} */
 export default function hydrate(jsx, parent) {
 	if (typeof window === 'undefined') return;
 	let isodata = document.querySelector('script[type=isodata]');


### PR DESCRIPTION
https://github.com/preactjs/preact/pull/3863 gave us a nicer `parent` type for core, but that never made its way here. We can just reuse `hydrates` type here from now on.