### PR TITLE
fix: Hydrate parent param type

### DIFF
--- a/src/hydrate.d.ts
+++ b/src/hydrate.d.ts
@@ -1,3 +1,3 @@
-import { hydrate } from 'preact';
+import { ComponentChild, ContainerNode } from 'preact';
 
-export default hydrate;
+export default function hydrate(jsx: ComponentChild, parent?: ContainerNode): void;


### PR DESCRIPTION
Fixes mistake in #51 (didn't mean to merge that one so early, got confused between PRs).

`parent` is an optional param here, falling back to `document.body`, so we can't use core's `hydrate` type as it is not optional there.