### PR TITLE
fix: Rest param segment not matching optional segment

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -58,7 +58,7 @@ export const exec = (url, route, matches = {}) => {
 		// segment match:
 		if (!m && param == val) continue;
 		// /foo/* match
-		if (!m && val && flag == '*') {
+		if (!m && flag == '*') {
 			matches.rest = '/' + url.slice(i).map(decodeURIComponent).join('/');
 			break;
 		}

--- a/test/node/router-match.test.js
+++ b/test/node/router-match.test.js
@@ -25,8 +25,11 @@ test('Param route', () => {
 });
 
 test('Param rest segment', () => {
-	const accurateResult = execPath('/user/foo', '/user/*');
-	assert.equal(accurateResult, { path: '/user/foo', params: {}, query: {}, rest: '/foo' });
+	const accurateResult = execPath('/user', '/user/*');
+	assert.equal(accurateResult, { path: '/user', params: {}, query: {}, rest: '/' });
+
+	const accurateResult2 = execPath('/user/foo', '/user/*');
+	assert.equal(accurateResult2, { path: '/user/foo', params: {}, query: {}, rest: '/foo' });
 
 	const inaccurateResult = execPath('/', '/user/:id/*');
 	assert.equal(inaccurateResult, undefined);

--- a/test/node/router-match.test.js
+++ b/test/node/router-match.test.js
@@ -25,11 +25,11 @@ test('Param route', () => {
 });
 
 test('Param rest segment', () => {
-	const accurateResult = execPath('/user', '/user/*');
-	assert.equal(accurateResult, { path: '/user', params: {}, query: {}, rest: '/' });
+	const accurateResult = execPath('/user/foo', '/user/*');
+	assert.equal(accurateResult, { path: '/user/foo', params: {}, query: {}, rest: '/foo' });
 
-	const accurateResult2 = execPath('/user/foo', '/user/*');
-	assert.equal(accurateResult2, { path: '/user/foo', params: {}, query: {}, rest: '/foo' });
+	const accurateResult2 = execPath('/user', '/user/*');
+	assert.equal(accurateResult2, { path: '/user', params: {}, query: {}, rest: '/' });
 
 	const inaccurateResult = execPath('/', '/user/:id/*');
 	assert.equal(inaccurateResult, undefined);


### PR DESCRIPTION
Basically we split the URL into segments, iterating over each segment to test if it matches a given param. Despite `*` meaning "0 or more", we were checking that it actually existed as a segment in the provided URL.

Imagine the URL `/movies` & the path `/movies/*`:

- The first segment (`movies`) has a value & matches the pattern
- There is no second segment so the `&& val` check fails

---

A few people have reported issues with the nesting routers over the past few months but no one has been able to provide a reproduction; I'm guessing this is the root behind all of them. Cheers to @sbesh91 for finding this.