### PR TITLE
Set _excess in preparation for v11

### DIFF
--- a/src/lazy.js
+++ b/src/lazy.js
@@ -42,7 +42,7 @@ options.__e = (err, newVNode, oldVNode) => {
 		while ((v = v.__)) {
 			if (v.__c && v.__c.__c) {
 				if (newVNode.__e == null) {
-					newVNode.__z = [oldVNode.__e];
+					newVNode.__c.__z = [oldVNode.__e];
 					newVNode.__e = oldVNode.__e; // ._dom
 					newVNode.__k = oldVNode.__k; // ._children
 				}

--- a/src/lazy.js
+++ b/src/lazy.js
@@ -42,6 +42,7 @@ options.__e = (err, newVNode, oldVNode) => {
 		while ((v = v.__)) {
 			if (v.__c && v.__c.__c) {
 				if (newVNode.__e == null) {
+					newVNode.__z = [oldVNode.__e];
 					newVNode.__e = oldVNode.__e; // ._dom
 					newVNode.__k = oldVNode.__k; // ._children
 				}


### PR DESCRIPTION
I think this is the issue behind the crash, the ref forwarding is expected to fail as we don't stop on vnodes anymore.

https://github.com/preactjs/ecosystem-ci/actions/runs/13334317934/job/37245956180