### PR TITLE
chore: Add basic issue templates to repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+- [ ] Check if updating to the latest `preact-iso` version resolves the issue
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Please provide a link to a StackBlitz/CodeSandbox/Codepen project or a GitHub repository that demonstrates the issue. You can use the following template on StackBlitz to get started: https://stackblitz.com/edit/create-preact-starter-routing
+
+Issues without reproductions will likely be closed, they're essential for ensuring we're all on the same page.
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+**Expected behavior**
+What should have happened when following the steps above?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+---
+
+**Describe the feature you'd love to see**
+A clear and concise description of what you'd love to see added to `preact-iso`.
+
+**Additional context (optional)**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Same as those we have in the Preact repo, but switches the Stackblitz template to one with routing & emphasizes that reproductions are necessary.