### PR TITLE
test: Minor clean up of router test suite

### DIFF
--- a/test/router.test.js
+++ b/test/router.test.js
@@ -635,7 +635,7 @@ describe('Router', () => {
 			}
 		});
 
-		it('should allow default browser navigation for links not matching the `limit` props (string)', async () => {
+		it('should allow default browser navigation for links not matching the `scope` props (string)', async () => {
 			render(
 				<LocationProvider scope="app">
 					<Links />
@@ -655,7 +655,7 @@ describe('Router', () => {
 			}
 		});
 
-		it('should intercept clicks on links matching the `limit` props (regex)', async () => {
+		it('should intercept clicks on links matching the `scope` props (regex)', async () => {
 			render(
 				<LocationProvider scope={/^\/app/}>
 					<Links />
@@ -676,7 +676,7 @@ describe('Router', () => {
 			}
 		});
 
-		it('should allow default browser navigation for links not matching the `limit` props (regex)', async () => {
+		it('should allow default browser navigation for links not matching the `scope` props (regex)', async () => {
 			render(
 				<LocationProvider scope={/^\/app/}>
 					<Links />

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -14,8 +14,8 @@ chai.use(sinonChai);
 
 /**
  * Usage:
- * - `await sleep(1)` for nav + loc/pushState check
- * - `await sleep(10)` for nav + component load check
+ * - `await sleep(1)` for nav + loc/pushState/sync component check
+ * - `await sleep(10)` for nav + async component check
  */
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
@@ -402,7 +402,7 @@ describe('Router', () => {
 		loadStart.resetHistory();
 		loadEnd.resetHistory();
 		routeChange.resetHistory();
-		await sleep(10);
+		await sleep(1);
 
 		expect(scratch).to.have.property('innerHTML', '<h1>A</h1><p>hello</p>');
 		expect(A).to.have.been.calledWith({ path: '/', query: {}, params: {}, rest: '' });
@@ -418,7 +418,7 @@ describe('Router', () => {
 				<p>hello</p>
 			</>
 		);
-		const A = sinon.fake(groggy(() => route('A'), 1));
+		const A = sinon.fake(() => route('A'));
 		const B = sinon.fake(groggy(() => route('B'), 1));
 		const loadStart = sinon.fake();
 		const loadEnd = sinon.fake();
@@ -441,15 +441,12 @@ describe('Router', () => {
 			scratch
 		);
 
-		await sleep(10);
-
 		A.resetHistory();
 		loadStart.resetHistory();
 		loadEnd.resetHistory();
 		routeChange.resetHistory();
 
 		loc.route('/b');
-
 		await sleep(1);
 
 		expect(loadStart).to.have.been.calledWith('/b');
@@ -460,7 +457,6 @@ describe('Router', () => {
 		loadStart.resetHistory();
 		loadEnd.resetHistory();
 		routeChange.resetHistory();
-
 		await sleep(10);
 
 		expect(scratch).to.have.property('innerHTML', '<h1>B</h1><p>hello</p>');
@@ -498,6 +494,7 @@ describe('Router', () => {
 
 		await sleep(10);
 
+		expect(loadEnd).to.have.been.calledWith('/');
 		loadEnd.resetHistory();
 
 		set('2');
@@ -716,7 +713,7 @@ describe('Router', () => {
 		Route.resetHistory();
 
 		loc.route('/programmatic');
-		await sleep(10);
+		await sleep(1);
 
 		expect(loc).to.deep.include({ url: '/programmatic' });
 		expect(scrollTo).to.have.been.calledWith(0, 0);
@@ -726,7 +723,7 @@ describe('Router', () => {
 		scrollTo.resetHistory();
 
 		scratch.querySelector('a').click();
-		await sleep(10);
+		await sleep(1);
 
 		expect(loc).to.deep.include({ url: '/link' });
 		expect(scrollTo).to.have.been.calledWith(0, 0);
@@ -762,7 +759,7 @@ describe('Router', () => {
 		Route.resetHistory();
 
 		scratch.querySelector('a[href="#foo"]').click();
-		await sleep(10);
+		await sleep(1);
 
 		// NOTE: we don't (currently) propagate in-page anchor navigations into context, to avoid useless renders.
 		expect(loc).to.deep.include({ url: '/' });
@@ -770,9 +767,8 @@ describe('Router', () => {
 		expect(pushState).not.to.have.been.called;
 		expect(location.hash).to.equal('#foo');
 
-
 		scratch.querySelector('a[href="/other#bar"]').click();
-		await sleep(10);
+		await sleep(1);
 
 		expect(Route).to.have.been.calledOnce;
 		expect(loc).to.deep.include({ url: '/other#bar', path: '/other' });

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -12,6 +12,11 @@ import './setup.js';
 const expect = chai.expect;
 chai.use(sinonChai);
 
+/**
+ * Usage:
+ * - `await sleep(1)` for nav + loc/pushState check
+ * - `await sleep(10)` for nav + component load check
+ */
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 // delayed lazy()
@@ -333,8 +338,6 @@ describe('Router', () => {
 			scratch
 		);
 
-		await sleep(10);
-
 		expect(scratch).to.have.property('innerHTML', '<h1>a</h1>');
 		expect(renderRefCount).to.equal(2);
 
@@ -541,7 +544,6 @@ describe('Router', () => {
 				</LocationProvider>,
 				scratch
 			);
-			await sleep(10);
 			Route.resetHistory();
 			clickHandler.resetHistory();
 			pushState.resetHistory();
@@ -552,8 +554,6 @@ describe('Router', () => {
 		// these should all be intercepted by the router.
 		for (const target of shouldIntercept) {
 			it(`should intercept clicks on links with ${getName(target)}`, async () => {
-				await sleep(10);
-
 				const sel = target == null ? `a:not([target])` : `a[target="${target}"]`;
 				const el = scratch.querySelector(sel);
 				if (!el) throw Error(`Unable to find link: ${sel}`);
@@ -570,8 +570,6 @@ describe('Router', () => {
 		// these should all navigate.
 		for (const target of shouldNavigate) {
 			it(`should allow default browser navigation for links with ${getName(target)}`, async () => {
-				await sleep(10);
-
 				const sel = target == null ? `a:not([target])` : `a[target="${target}"]`;
 				const el = scratch.querySelector(sel);
 				if (!el) throw Error(`Unable to find link: ${sel}`);
@@ -624,11 +622,9 @@ describe('Router', () => {
 				</LocationProvider>,
 				scratch
 			);
-			await sleep(10);
 
 			for (const url of shouldIntercept) {
-				const el = scratch.querySelector(`a[href="${url}"]`);
-				el.click();
+				scratch.querySelector(`a[href="${url}"]`).click();
 				await sleep(1);
 				expect(loc).to.deep.include({ url });
 				expect(pushState).to.have.been.calledWith(null, '', url);
@@ -647,11 +643,9 @@ describe('Router', () => {
 				</LocationProvider>,
 				scratch
 			);
-			await sleep(10);
 
 			for (const url of shouldNavigate) {
-				const el = scratch.querySelector(`a[href="${url}"]`);
-				el.click();
+				scratch.querySelector(`a[href="${url}"]`).click();
 				await sleep(1);
 				expect(pushState).not.to.have.been.called;
 				expect(clickHandler).to.have.been.called;
@@ -669,11 +663,9 @@ describe('Router', () => {
 				</LocationProvider>,
 				scratch
 			);
-			await sleep(10);
 
 			for (const url of shouldIntercept) {
-				const el = scratch.querySelector(`a[href="${url}"]`);
-				el.click();
+				scratch.querySelector(`a[href="${url}"]`).click();
 				await sleep(1);
 				expect(loc).to.deep.include({ url });
 				expect(pushState).to.have.been.calledWith(null, '', url);
@@ -692,11 +684,9 @@ describe('Router', () => {
 				</LocationProvider>,
 				scratch
 			);
-			await sleep(10);
 
 			for (const url of shouldNavigate) {
-				const el = scratch.querySelector(`a[href="${url}"]`);
-				el.click();
+				scratch.querySelector(`a[href="${url}"]`).click();
 				await sleep(1);
 				expect(pushState).not.to.have.been.called;
 				expect(clickHandler).to.have.been.called;
@@ -721,14 +711,13 @@ describe('Router', () => {
 			scratch
 		);
 
-		await sleep(20);
-
 		expect(scrollTo).not.to.have.been.called;
 		expect(Route).to.have.been.calledOnce;
 		Route.resetHistory();
 
 		loc.route('/programmatic');
 		await sleep(10);
+
 		expect(loc).to.deep.include({ url: '/programmatic' });
 		expect(scrollTo).to.have.been.calledWith(0, 0);
 		expect(scrollTo).to.have.been.calledOnce;
@@ -738,13 +727,13 @@ describe('Router', () => {
 
 		scratch.querySelector('a').click();
 		await sleep(10);
+
 		expect(loc).to.deep.include({ url: '/link' });
 		expect(scrollTo).to.have.been.calledWith(0, 0);
 		expect(scrollTo).to.have.been.calledOnce;
 		expect(Route).to.have.been.calledOnce;
 		Route.resetHistory();
 
-		await sleep(10);
 		scrollTo.restore();
 	});
 
@@ -771,20 +760,20 @@ describe('Router', () => {
 
 		expect(Route).to.have.been.calledOnce;
 		Route.resetHistory();
-		await sleep(20);
 
 		scratch.querySelector('a[href="#foo"]').click();
-		await sleep(20);
+		await sleep(10);
+
 		// NOTE: we don't (currently) propagate in-page anchor navigations into context, to avoid useless renders.
 		expect(loc).to.deep.include({ url: '/' });
 		expect(Route).not.to.have.been.called;
 		expect(pushState).not.to.have.been.called;
 		expect(location.hash).to.equal('#foo');
 
-		await sleep(10);
 
 		scratch.querySelector('a[href="/other#bar"]').click();
 		await sleep(10);
+
 		expect(Route).to.have.been.calledOnce;
 		expect(loc).to.deep.include({ url: '/other#bar', path: '/other' });
 		expect(pushState).to.have.been.called;
@@ -811,10 +800,10 @@ describe('Router', () => {
 
 		expect(Route).to.have.been.calledOnce;
 		Route.resetHistory();
-		await sleep(20);
 
 		scratch.querySelector('a[href="/foo#foo"]').click();
-		await sleep(20);
+		await sleep(10);
+
 		expect(Route).to.have.been.calledOnce;
 		expect(loc).to.deep.include({ url: '/foo#foo', path: '/foo' });
 		expect(pushState).to.have.been.called;
@@ -847,7 +836,7 @@ describe('Router', () => {
 		);
 
 		scratch.querySelector('a[href="/foo/bar/bob"]').click();
-		await sleep(20);
+		await sleep(1);
 		expect(route).to.deep.include({ path: '/bob', params: { id: 'bar' } });
 	});
 
@@ -876,7 +865,7 @@ describe('Router', () => {
 		);
 
 		scratch.querySelector('a[href="/foo/bar/bob"]').click();
-		await sleep(20);
+		await sleep(1);
 		expect(params).to.deep.include({ id: 'bar' });
 	});
 
@@ -894,7 +883,6 @@ describe('Router', () => {
 			scratch
 		);
 
-		await sleep(20);
 		loc.route("/foo", true);
 		expect(pushState).not.to.have.been.called;
 		expect(replaceState).to.have.been.calledWith(null, "", "/foo");


### PR DESCRIPTION
Not an issue per se, but I noticed we have a bunch of extraneous `sleep()` calls in our test suite. In a couple cases the tests are a bit less clear due to the timings, as it'd make you think the test needed to wait for something when in reality the `sleep` is entirely superfluous.