### PR TITLE
fix: Resolve issue with shadow DOM

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -16,8 +16,7 @@ const UPDATE = (state, url) => {
 			return state;
 		}
 
-		const elements = url.composedPath();
-		const link = elements.find(el => el.tagName?.toLowerCase() === 'a' && el.href),
+		const link = url.composedPath().find(el => el.nodeName == 'A' && el.href),
 			href = link && link.getAttribute('href');
 		if (
 			!link ||

--- a/src/router.js
+++ b/src/router.js
@@ -16,7 +16,8 @@ const UPDATE = (state, url) => {
 			return state;
 		}
 
-		const link = url.target.closest('a[href]'),
+		const elements = url.composedPath();
+		const link = elements.find(el => el.tagName?.toLowerCase() === 'a' && el.href),
 			href = link && link.getAttribute('href');
 		if (
 			!link ||


### PR DESCRIPTION
Router should now be able to find <a> tags within open shadow DOMs.

This is a fix for #4.
