### PR TITLE
fix: Correct peer dep range for Preact v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"test:node": "uvu test/node"
 	},
 	"peerDependencies": {
-		"preact": ">=10 || >= 11",
+		"preact": ">=10 || >= 11.0.0-0",
 		"preact-render-to-string": ">=6.4.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This should be what we want instead I believe:

```js
import * as semver from 'semver';

const versions = ['11.0.0-beta.0', '11.0.0', '11.1.2'];

for (const version of versions) {
	const res = semver.satisfies('11.0.0-beta.0', '>= 11.0.0-0');
	console.log(version, res); // All true
}
```