### PR TITLE
chore: Bump RTS devDep for v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,13 @@
 				"htm": "^3.1.1",
 				"kleur": "^4.1.5",
 				"preact": "^10.26.5",
-				"preact-render-to-string": "^6.5.11",
+				"preact-render-to-string": "^6.6.1",
 				"sinon": "^18.0.0",
 				"sinon-chai": "^4.0.0",
 				"uvu": "^0.5.6"
 			},
 			"peerDependencies": {
-				"preact": ">=10 || >= 11",
+				"preact": ">=10 || >= 11.0.0-0",
 				"preact-render-to-string": ">=6.4.0"
 			}
 		},
@@ -3311,13 +3311,13 @@
 			}
 		},
 		"node_modules/preact-render-to-string": {
-			"version": "6.5.11",
-			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
-			"integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+			"version": "6.6.1",
+			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.6.1.tgz",
+			"integrity": "sha512-IIMfXRjmbSP9QmG18WJLQa4Z4yx3J0VC9QN5q9z2XYlWSzFlJ+bSm/AyLyyV/YFwjof1OXFX2Mz6Ao60LXudJg==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
-				"preact": ">=10"
+				"preact": ">=10 || >= 11.0.0-0"
 			}
 		},
 		"node_modules/progress": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"htm": "^3.1.1",
 		"kleur": "^4.1.5",
 		"preact": "^10.26.5",
-		"preact-render-to-string": "^6.5.11",
+		"preact-render-to-string": "^6.6.1",
 		"sinon": "^18.0.0",
 		"sinon-chai": "^4.0.0",
 		"uvu": "^0.5.6"


### PR DESCRIPTION
Looks to be breaking our [ecosystem CI](https://github.com/preactjs/ecosystem-ci/actions/runs/17161319973/job/48691339941), the version of RTS in our lockfile here doesn't accept v11 so it'll need a bump to avoid Preact copies.