### PR TITLE
Implemented router's URL matching logic in multiple (non-JS) languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,6 @@ export async function prerender(data) {
 }
 ```
 
-## Non-JS Server
-
-prerendering is not an option for servers that cannot run JavaScript. But you can still opt to add preload head tags for JS and CSS for the pages while you serve the app shell in the `<body>` tag. Doing so would speed up your page load. However to achieve that, your server needs to be able to understand which preact-iso route would load for a given URL. [polyglot-utils](https://github.com/preactjs/preact-iso/tree/main/polyglot-utils/) provides utilities and guides on how to achieve that.
-
 ## Nested Routing
 
 Some applications would benefit from having routers of multiple levels, allowing to break down the routing logic into smaller components. This is especially useful for larger applications, and we solve this by allowing for multiple nested `<Router>` components.
@@ -145,6 +141,10 @@ The `<Movies>` component will be used for the following routes:
 It will not be used for any of the following:
   - `/movies`
   - `/movies/`
+
+## Non-JS Servers
+
+For those using non-JS servers (e.g., PHP, Python, Ruby, etc.) to serve your Preact app, you may want to use our ["polyglot-utils"](./polyglot-utils), a collection of our route matching logic ported to various other languages. Combined with a route manifest, this will allow your server to better understand which assets will be needed at runtime for a given URL, allowing you to say insert preload tags for those assets in the HTML head prior to serving the page.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ export async function prerender(data) {
 }
 ```
 
+## Non-JS Server
+
+prerendering is not an option for servers that cannot run JavaScript. But you can still opt to add preload head tags for JS and CSS for the pages while you serve the app shell in the `<body>` tag. Doing so would speed up your page load. However to achieve that, your server needs to be able to understand which preact-iso route would load for a given URL. [polyglot-utils](https://github.com/preactjs/preact-iso/tree/main/polyglot-utils/) provides utilities and guides on how to achieve that.
+
 ## Nested Routing
 
 Some applications would benefit from having routers of multiple levels, allowing to break down the routing logic into smaller components. This is especially useful for larger applications, and we solve this by allowing for multiple nested `<Router>` components.

--- a/polyglot-utils/.gitignore
+++ b/polyglot-utils/.gitignore
@@ -1,0 +1,5 @@
+# Language-specific files to ignore
+__pycache__/
+*.pyc
+.venv/
+.ruby-version

--- a/polyglot-utils/README.md
+++ b/polyglot-utils/README.md
@@ -1,0 +1,122 @@
+# Preact ISO URL Pattern Matching - Polyglot Utils
+
+Multi-language implementations of URL pattern matching utilities for building bespoke server setups that need to preload JS/CSS resources or handle early 404 responses.
+
+## Use Case
+
+This utility is designed for server languages that **cannot do SSR/prerendering** but still want to provide better experiences. It enables servers to:
+
+- **Add preload head tags** for JS,CSS before serving HTML
+- **Return early 404 pages** for unmatched routes
+- **Generate dynamic titles** based on route parameters
+
+## How can I implement preloading of JS, CSS?
+
+Typical implementation flow:
+
+1. **Build-time Setup:**
+   - Write your routes as an array in a JS file
+   - Create a build script that exports route patterns and entry files to a `.json` file
+   - Configure your frontend build tool to output a `manifest` file mapping entry files to final fingerprinted/hashed output JS/CSS files and dependencies
+
+2. **Server-time Processing:**
+   - Load the JSON route file when a request comes in
+   - Match the requested URL against each route pattern until you find a match
+   - Once matched, you have the source entry `.jsx` file
+   - Load the build manifest file to find which JS chunk contains that code and its dependency files
+   - Generate `<link rel="preload">` tags for each dependency (JS, CSS, images, icons)
+   - Inject those head tags into the HTML before serving
+
+3. **Result:**
+   - Browsers start downloading critical resources immediately
+   - Faster page loads without full SSR complexity
+   - Early 404s for invalid routes
+
+### Example - preloading of JS, CSS
+
+Here's how you might integrate this into a server setup:
+
+### 1. Route Configuration (routes.json)
+```json
+[
+  {
+    "path": "/users/:userId/posts",
+    "component": "pages/UserPosts.jsx",
+    "title": "Posts by :userId"
+  },
+  {
+    "path": "/products/:category/:id",
+    "component": "pages/Product.jsx",
+    "title": "Product :id"
+  }
+]
+```
+
+### 2. Build Manifest (manifest.json)
+```json
+{
+  "pages/UserPosts.jsx": {
+    "file": "assets/UserPosts-abc123.js",
+    "css": ["assets/UserPosts-def456.css"],
+    "imports": ["chunks/shared-ghi789.js"]
+  }
+}
+```
+
+### 3. Server Implementation
+```python
+# Python example
+import json
+
+routes = json.load(open('routes.json'))
+manifest = json.load(open('manifest.json'))
+
+def handle_request(url_path):
+    for route in routes:
+        matches = preact_iso_url_pattern_match(url_path, route['path'])
+        if matches:
+            # Generate preload tags
+            component = route['component']
+            entry_info = manifest[component]
+            
+            preload_tags = []
+            for js_file in [entry_info['file']] + entry_info.get('imports', []):
+                preload_tags.append(f'<link rel="modulepreload" crossorigin href="{js_file}">')
+            
+            for css_file in entry_info.get('css', []):
+                preload_tags.append(f'<link rel="stylesheet" crossorigin href="{css_file}">')
+            # Generate dynamic title
+            title = route['title']
+            for param, value in matches['params'].items():
+                title = title.replace(f':{param}', value)
+            
+            return {
+                'preload_tags': preload_tags,
+                'title': title,
+                'params': matches['params']
+            }
+    
+    # No match found - return early 404
+    return None
+```
+
+This approach gives you the performance benefits of resource preloading without the complexity of full server-side rendering!
+
+## Available Languages
+
+Go, PHP, Python and Ruby.
+
+Find the corresponding language's sub-directory. Each language has a README that contains usage examples and API reference.
+
+## Running Tests
+
+```bash
+# Run all tests across all languages
+./run_tests.sh
+
+# Or run individual language tests
+cd go && go test -v
+cd python && python3 test_preact_iso_url_pattern.py  
+cd ruby && ruby test_preact_iso_url_pattern.rb
+cd php && php test_preact_iso_url_pattern.php
+```

--- a/polyglot-utils/README.md
+++ b/polyglot-utils/README.md
@@ -122,11 +122,11 @@ def handle_request(url_path):
             # Generate preload tags
             component = route['component']
             entry_info = manifest[component]
-            
+
             preload_tags = []
             for js_file in [entry_info['file']] + entry_info.get('imports', []):
                 preload_tags.append(f'<link rel="modulepreload" crossorigin href="{js_file}">')
-            
+
             for css_file in entry_info.get('css', []):
                 preload_tags.append(f'<link rel="stylesheet" crossorigin href="{css_file}">')
 
@@ -134,13 +134,13 @@ def handle_request(url_path):
             title = route['title']
             for param, value in matches['params'].items():
                 title = title.replace(f':{param}', value)
-            
+
             return {
                 'preload_tags': preload_tags,
                 'title': title,
                 'params': matches['params']
             }
-    
+
     # No match found - return early 404
     return None
 ```
@@ -161,7 +161,7 @@ Find the corresponding language's sub-directory. Each language has a README that
 
 # Or run individual language tests
 cd go && go test -v
-cd python && python3 test_preact_iso_url_pattern.py  
+cd python && python3 test_preact_iso_url_pattern.py
 cd ruby && ruby test_preact_iso_url_pattern.rb
 cd php && php test_preact_iso_url_pattern.php
 ```

--- a/polyglot-utils/go/README.md
+++ b/polyglot-utils/go/README.md
@@ -1,0 +1,67 @@
+# Go Implementation
+
+URL pattern matching utility for Go servers.
+
+## Setup
+
+Code tested on Go 1.24.x.
+
+```sh
+# If using in a project, initialize go module
+go mod init myproject
+# No third party dependencies needed. Just run the tests or use the function directly
+```
+
+## Running Tests
+
+```sh
+go test -v
+```
+
+## Usage
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    matches := preactIsoUrlPatternMatch("/users/test%40example.com/posts", "/users/:userId/posts", nil)
+    if matches != nil {
+        fmt.Printf("User ID: %s\n", matches.Params["userId"]) // Output: test@example.com
+    }
+}
+```
+
+## Function Signature
+
+```go
+func preactIsoUrlPatternMatch(url, route string, matches *Matches) *Matches
+```
+
+### Parameters
+
+- `url` (string): The URL path to match
+- `route` (string): The route pattern with parameters
+- `matches` (*Matches): Optional pre-existing matches to extend
+
+### Return Value
+
+Returns a `*Matches` struct on success, or `nil` if no match:
+
+```go
+type Matches struct {
+    Params map[string]string
+    Rest   string
+}
+```
+
+## Route Patterns
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| `/users/:id` | Named parameter | `{id: "123"}` |
+| `/users/:id?` | Optional parameter | `{id: ""}` |
+| `/files/:path+` | Required rest parameter | `{path: "docs/readme.txt"}` |
+| `/static/:path*` | Optional rest parameter | `{path: "css/main.css"}` |
+| `/static/*` | Anonymous wildcard | `{Rest: "/images/logo.png"}` |

--- a/polyglot-utils/go/go.mod
+++ b/polyglot-utils/go/go.mod
@@ -1,0 +1,3 @@
+module myproject
+
+go 1.13

--- a/polyglot-utils/go/preact_iso_url_pattern.go
+++ b/polyglot-utils/go/preact_iso_url_pattern.go
@@ -1,0 +1,122 @@
+// Run program: go run preact-iso-url-pattern.go
+
+package main
+
+import (
+	// "fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+type Matches struct {
+	Params map[string]string `json:"params"`
+	Rest   string            `json:"rest,omitempty"`
+}
+
+func preactIsoUrlPatternMatch(urlStr, route string, matches *Matches) *Matches {
+	if matches == nil {
+		matches = &Matches{
+			Params: make(map[string]string),
+		}
+	}
+	urlParts := filterEmpty(strings.Split(urlStr, "/"))
+	routeParts := filterEmpty(strings.Split(route, "/"))
+
+	for i := 0; i < max(len(urlParts), len(routeParts)); i++ {
+		var m, param, flag string
+		if i < len(routeParts) {
+			re := regexp.MustCompile(`^(:?)(.*?)([+*?]?)$`)
+			matches := re.FindStringSubmatch(routeParts[i])
+			if len(matches) > 3 {
+				m, param, flag = matches[1], matches[2], matches[3]
+			}
+		}
+
+		var val string
+		if i < len(urlParts) {
+			val = urlParts[i]
+		}
+
+		// segment match:
+		if m == "" && param == val {
+			continue
+		}
+
+		// /foo/* match
+		if m == "" && val != "" && flag == "*" {
+			matches.Rest = "/" + strings.Join(urlParts[i:], "/")
+			break
+		}
+
+		// segment mismatch / missing required field:
+		if m == "" || (val == "" && flag != "?" && flag != "*") {
+			return nil
+		}
+
+		rest := flag == "+" || flag == "*"
+
+		// rest (+/*) match:
+		if rest {
+			decodedParts := make([]string, len(urlParts[i:]))
+			for j, part := range urlParts[i:] {
+				decoded, err := url.QueryUnescape(part)
+				if err != nil {
+					decoded = part // fallback to original if decode fails
+				}
+				decodedParts[j] = decoded
+			}
+			val = strings.Join(decodedParts, "/")
+		} else if val != "" {
+			// normal/optional field: decode val (like JavaScript does)
+			decoded, err := url.QueryUnescape(val)
+			if err != nil {
+				decoded = urlParts[i]
+			}
+			val = decoded
+		}
+
+		matches.Params[param] = val
+
+		if rest {
+			break
+		}
+	}
+
+	return matches
+}
+
+func filterEmpty(s []string) []string {
+	var result []string
+	for _, str := range s {
+		if str != "" {
+			result = append(result, str)
+		}
+	}
+	return result
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Example usage:
+// func main() {
+// 	params := &Matches{Params: make(map[string]string)}
+// 	fmt.Println(preactIsoUrlPatternMatch("/foo/bar%20baz", "/foo/:param", params))
+//
+// 	params := &Matches{Params: make(map[string]string)}
+// 	fmt.Println(preactIsoUrlPatternMatch("/foo/bar/baz", "/foo/*"))
+//
+// 	params := &Matches{Params: make(map[string]string)}
+// 	fmt.Println(preactIsoUrlPatternMatch("/foo", "/foo/:param?"))
+//
+// 	params := &Matches{Params: make(map[string]string)}
+// 	fmt.Println(preactIsoUrlPatternMatch("/foo/bar", "/bar/:param"))
+//
+// 	params := &Matches{Params: make(map[string]string)}
+// 	fmt.Println(preactIsoUrlPatternMatch("/users/test%40example.com/posts", "/users/:userId/posts"))
+// }

--- a/polyglot-utils/go/preact_iso_url_pattern.go
+++ b/polyglot-utils/go/preact_iso_url_pattern.go
@@ -37,7 +37,7 @@ func preactIsoUrlPatternMatch(urlStr, route string, matches *Matches) *Matches {
 		if i < len(urlParts) {
 			val = urlParts[i]
 		}
-		
+
 		// segment match:
 		if m == "" && param != "" && param == val {
 			continue

--- a/polyglot-utils/go/preact_iso_url_pattern.go
+++ b/polyglot-utils/go/preact_iso_url_pattern.go
@@ -37,9 +37,9 @@ func preactIsoUrlPatternMatch(urlStr, route string, matches *Matches) *Matches {
 		if i < len(urlParts) {
 			val = urlParts[i]
 		}
-
+		
 		// segment match:
-		if m == "" && param == val {
+		if m == "" && param != "" && param == val {
 			continue
 		}
 

--- a/polyglot-utils/go/preact_iso_url_pattern_test.go
+++ b/polyglot-utils/go/preact_iso_url_pattern_test.go
@@ -1,0 +1,637 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPreactIsoUrlPatternMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		route    string
+		matches  *Matches
+		expected *Matches
+	}{
+		// Base route tests
+		{
+			name:     "Base route - exact match",
+			url:      "/",
+			route:    "/",
+			matches:  nil,
+			expected: &Matches{Params: map[string]string{}},
+		},
+		{
+			name:     "Base route - no match",
+			url:      "/user/1",
+			route:    "/",
+			matches:  nil,
+			expected: nil,
+		},
+
+		// Param route tests
+		{
+			name:    "Param route - match",
+			url:     "/user/2",
+			route:   "/user/:id",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": "2"},
+			},
+		},
+		{
+			name:     "Param route - no match",
+			url:      "/",
+			route:    "/user/:id",
+			matches:  nil,
+			expected: nil,
+		},
+
+		// Rest segment tests
+		{
+			name:    "Rest segment - match",
+			url:     "/user/foo",
+			route:   "/user/*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{},
+				Rest:   "/foo",
+			},
+		},
+		{
+			name:     "Rest segment - no match",
+			url:      "/",
+			route:    "/user/:id/*",
+			matches:  nil,
+			expected: nil,
+		},
+
+		// Param route with rest segment
+		{
+			name:    "Param with rest - single segment",
+			url:     "/user/2/foo",
+			route:   "/user/:id/*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": "2"},
+				Rest:   "/foo",
+			},
+		},
+		{
+			name:    "Param with rest - multiple segments",
+			url:     "/user/2/foo/bar/bob",
+			route:   "/user/:id/*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": "2"},
+				Rest:   "/foo/bar/bob",
+			},
+		},
+
+		// Optional param tests
+		{
+			name:    "Optional param - empty",
+			url:     "/user",
+			route:   "/user/:id?",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": ""},
+			},
+		},
+		{
+			name:     "Optional param - no match base",
+			url:      "/",
+			route:    "/user/:id?",
+			matches:  nil,
+			expected: nil,
+		},
+
+		// Optional rest param tests (/:x*)
+		{
+			name:    "Optional rest param - empty",
+			url:     "/user",
+			route:   "/user/:id*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": ""},
+			},
+		},
+		{
+			name:    "Optional rest param - with segments",
+			url:     "/user/foo/bar",
+			route:   "/user/:id*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": "foo/bar"},
+			},
+		},
+
+		// Required rest param tests (/:x+)
+		{
+			name:    "Required rest param - single segment",
+			url:     "/user/foo",
+			route:   "/user/:id+",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": "foo"},
+			},
+		},
+		{
+			name:    "Required rest param - multiple segments",
+			url:     "/user/foo/bar",
+			route:   "/user/:id+",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": "foo/bar"},
+			},
+		},
+		{
+			name:     "Required rest param - empty (should fail)",
+			url:      "/user",
+			route:    "/user/:id+",
+			matches:  nil,
+			expected: nil,
+		},
+		{
+			name:     "Required rest param - root mismatch",
+			url:      "/",
+			route:    "/user/:id+",
+			matches:  nil,
+			expected: nil,
+		},
+
+		// Leading/trailing slashes
+		{
+			name:    "Leading/trailing slashes",
+			url:     "/about-late/_SEGMENT1_/_SEGMENT2_/",
+			route:   "/about-late/:seg1/:seg2/",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{
+					"seg1": "_SEGMENT1_",
+					"seg2": "_SEGMENT2_",
+				},
+			},
+		},
+
+		// URL encoding tests
+		{
+			name:    "URL encoded param",
+			url:     "/foo/bar%20baz",
+			route:   "/foo/:param",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"param": "bar baz"},
+			},
+		},
+		{
+			name:    "URL encoded email in param",
+			url:     "/users/test%40example.com/posts",
+			route:   "/users/:userId/posts",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"userId": "test@example.com"},
+			},
+		},
+
+		// Complex rest segment with encoding
+		{
+			name:    "Rest segment with encoded parts",
+			url:     "/api/path/with%20spaces/and%2Fslashes",
+			route:   "/api/:path+",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"path": "path/with spaces/and/slashes"},
+			},
+		},
+
+		// Edge cases
+		{
+			name:     "Empty route",
+			url:      "/foo",
+			route:    "",
+			matches:  nil,
+			expected: nil,
+		},
+		{
+			name:     "Empty url with param",
+			url:      "",
+			route:    "/:param",
+			matches:  nil,
+			expected: nil,
+		},
+		{
+			name:    "Multiple optional params",
+			url:     "/foo",
+			route:   "/:a?/:b?/:c?",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"a": "foo", "b": "", "c": ""},
+			},
+		},
+		{
+			name:    "Mixed required and optional params",
+			url:     "/foo/bar",
+			route:   "/:required/:optional?",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"required": "foo", "optional": "bar"},
+			},
+		},
+		{
+			name:    "Mixed required and optional params - missing optional",
+			url:     "/foo",
+			route:   "/:required/:optional?",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"required": "foo", "optional": ""},
+			},
+		},
+
+		// Test with pre-existing matches
+		{
+			name:    "Pre-existing matches object",
+			url:     "/foo/bar",
+			route:   "/:first/:second",
+			matches: &Matches{Params: map[string]string{"existing": "value"}},
+			expected: &Matches{
+				Params: map[string]string{
+					"existing": "value",
+					"first":    "foo",
+					"second":   "bar",
+				},
+			},
+		},
+
+		// Wildcard anonymous rest
+		{
+			name:    "Anonymous wildcard rest",
+			url:     "/static/css/main.css",
+			route:   "/static/*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{},
+				Rest:   "/css/main.css",
+			},
+		},
+
+		// Complex nested paths
+		{
+			name:    "Complex nested path with multiple params",
+			url:     "/api/v1/users/123/posts/456/comments",
+			route:   "/api/:version/users/:userId/posts/:postId/comments",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{
+					"version": "v1",
+					"userId":  "123",
+					"postId":  "456",
+				},
+			},
+		},
+
+		// Test case where route is longer than URL
+		{
+			name:     "Route longer than URL - required param missing",
+			url:      "/api",
+			route:    "/api/:version/:resource",
+			matches:  nil,
+			expected: nil,
+		},
+		{
+			name:    "Route longer than URL - optional param",
+			url:     "/api",
+			route:   "/api/:version?",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"version": ""},
+			},
+		},
+
+		// JavaScript-specific behavior tests
+		{
+			name:    "Empty string should be handled as undefined for optional rest",
+			url:     "/user",
+			route:   "/user/:id*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": ""},
+			},
+		},
+		{
+			name:    "Multiple slashes in URL should be normalized",
+			url:     "//user//123//",
+			route:   "/user/:id",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": "123"},
+			},
+		},
+		{
+			name:    "Route with multiple slashes",
+			url:     "/user/123",
+			route:   "//user//:id//",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"id": "123"},
+			},
+		},
+		{
+			name:    "Special characters in param names",
+			url:     "/user/123",
+			route:   "/user/:user_id",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"user_id": "123"},
+			},
+		},
+		{
+			name:    "Param with numbers",
+			url:     "/api/v1",
+			route:   "/api/:version1",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"version1": "v1"},
+			},
+		},
+		{
+			name:    "Rest param with single character",
+			url:     "/a/b",
+			route:   "/:x+",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"x": "a/b"},
+			},
+		},
+		{
+			name:    "Complex URL encoding in rest params",
+			url:     "/files/folder%2Fsubfolder/file%20name.txt",
+			route:   "/files/:path+",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"path": "folder/subfolder/file name.txt"},
+			},
+		},
+		{
+			name:    "Question mark in URL (not query param)",
+			url:     "/search/what%3F",
+			route:   "/search/:query",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"query": "what?"},
+			},
+		},
+		{
+			name:    "Plus sign in URL",
+			url:     "/math/1%2B1",
+			route:   "/math/:expression",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"expression": "1+1"},
+			},
+		},
+		{
+			name:    "Hash in URL (encoded)",
+			url:     "/tag/%23javascript",
+			route:   "/tag/:name",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"name": "#javascript"},
+			},
+		},
+		{
+			name:    "Ampersand in URL",
+			url:     "/search/cats%26dogs",
+			route:   "/search/:query",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"query": "cats&dogs"},
+			},
+		},
+		{
+			name:    "Unicode characters",
+			url:     "/user/José",
+			route:   "/user/:name",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"name": "José"},
+			},
+		},
+		{
+			name:    "Unicode characters encoded",
+			url:     "/user/Jos%C3%A9",
+			route:   "/user/:name",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"name": "José"},
+			},
+		},
+		{
+			name:    "Very long param",
+			url:     "/data/" + strings.Repeat("a", 1000),
+			route:   "/data/:content",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"content": strings.Repeat("a", 1000)},
+			},
+		},
+		{
+			name:    "Empty segments in middle of URL",
+			url:     "/api//v1//users",
+			route:   "/api/v1/users",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{},
+			},
+		},
+		{
+			name:    "Route with only wildcards",
+			url:     "/anything/goes/here",
+			route:   "*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{},
+				Rest:   "/anything/goes/here",
+			},
+		},
+		{
+			name:    "Multiple consecutive optional params",
+			url:     "/a/b",
+			route:   "/:first?/:second?/:third?/:fourth?",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{
+					"first":  "a",
+					"second": "b",
+					"third":  "",
+					"fourth": "",
+				},
+			},
+		},
+		{
+			name:    "Zero-width param names (edge case)",
+			url:     "/test",
+			route:   "/:?",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{"": "test"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := preactIsoUrlPatternMatch(tt.url, tt.route, tt.matches)
+
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("Expected nil, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Errorf("Expected %+v, got nil", tt.expected)
+				return
+			}
+
+			// Detailed debugging for failing tests
+			if !reflect.DeepEqual(result.Params, tt.expected.Params) {
+				t.Errorf("Params mismatch for url=%q route=%q", tt.url, tt.route)
+				t.Errorf("  Expected: %+v", tt.expected.Params)
+				t.Errorf("  Got:      %+v", result.Params)
+
+				// Additional debug info for rest param cases
+				if strings.Contains(tt.route, "+") || strings.Contains(tt.route, "*") {
+					urlParts := filterEmpty(strings.Split(tt.url, "/"))
+					routeParts := filterEmpty(strings.Split(tt.route, "/"))
+					t.Errorf("  Debug: urlParts=%v, routeParts=%v", urlParts, routeParts)
+				}
+			}
+
+			// Check rest
+			if result.Rest != tt.expected.Rest {
+				t.Errorf("Rest mismatch. Expected %q, got %q", tt.expected.Rest, result.Rest)
+			}
+		})
+	}
+}
+
+// Test to document expected JavaScript behavior for debugging
+func TestJavaScriptBehaviorReference(t *testing.T) {
+	// These tests document what the JavaScript version should return
+	// for direct comparison with Go implementation
+
+	t.Run("JavaScript rest param behavior", func(t *testing.T) {
+		// In JavaScript: url.slice(i).map(decodeURIComponent).join('/') || undefined
+		// This means for "/user/foo/bar" with route "/user/:id*":
+		// - url = ["user", "foo", "bar"]
+		// - route = ["user", ":id*"]
+		// - At i=1: url.slice(1) = ["foo", "bar"]
+		// - joined: "foo/bar"
+		// - Result: {params: {id: "foo/bar"}}
+
+		t.Logf("Expected: rest params should join ALL remaining segments with '/'")
+		t.Logf("Go issue: likely only taking first segment instead of all remaining")
+	})
+
+	t.Run("JavaScript URL encoding behavior", func(t *testing.T) {
+		// JavaScript uses decodeURIComponent on each segment
+		// For rest params, it decodes EACH segment then joins with '/'
+
+		t.Logf("Expected: each URL segment should be decoded separately")
+		t.Logf("For rest params: decode each segment, then join with '/'")
+	})
+}
+
+// Debug helper to trace execution
+func TestDebugSpecificCase(t *testing.T) {
+	t.Run("Debug rest param multiple segments", func(t *testing.T) {
+		url := "/user/foo/bar"
+		route := "/user/:id*"
+
+		t.Logf("Testing: url=%q route=%q", url, route)
+
+		// Manual trace of what should happen:
+		urlParts := filterEmpty(strings.Split(url, "/"))
+		routeParts := filterEmpty(strings.Split(route, "/"))
+
+		t.Logf("urlParts: %v", urlParts)
+		t.Logf("routeParts: %v", routeParts)
+		t.Logf("Expected at i=1: should take urlParts[1:] = %v", urlParts[1:])
+		t.Logf("Expected result: %q", strings.Join(urlParts[1:], "/"))
+
+		result := preactIsoUrlPatternMatch(url, route, nil)
+		if result != nil {
+			t.Logf("Actual result: %+v", result)
+		} else {
+			t.Logf("Actual result: nil")
+		}
+	})
+}
+
+func TestFilterEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "no empty strings",
+			input:    []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "with empty strings",
+			input:    []string{"", "a", "", "b", ""},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "all empty strings",
+			input:    []string{"", "", ""},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterEmpty(tt.input)
+			// Handle nil slice vs empty slice comparison
+			if len(result) == 0 && len(tt.expected) == 0 {
+				return // Both are effectively empty
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Expected %+v, got %+v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMax(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     int
+		expected int
+	}{
+		{"a greater", 5, 3, 5},
+		{"b greater", 3, 5, 5},
+		{"equal", 4, 4, 4},
+		{"negative", -1, -5, -1},
+		{"zero", 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := max(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("max(%d, %d) = %d, expected %d", tt.a, tt.b, result, tt.expected)
+			}
+		})
+	}
+}

--- a/polyglot-utils/go/preact_iso_url_pattern_test.go
+++ b/polyglot-utils/go/preact_iso_url_pattern_test.go
@@ -252,32 +252,23 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name:    "Multiple optional params",
-			url:     "/foo",
-			route:   "/:a?/:b?/:c?",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"a": "foo", "b": "", "c": ""},
-			},
-		},
-		{
-			name:    "Mixed required and optional params",
-			url:     "/foo/bar",
-			route:   "/:required/:optional?",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"required": "foo", "optional": "bar"},
-			},
-		},
-		{
-			name:    "Mixed required and optional params - missing optional",
-			url:     "/foo",
-			route:   "/:required/:optional?",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"required": "foo", "optional": ""},
-			},
-		},
+      name:    "Mixed required and optional params",
+      url:     "/foo/bar",
+      route:   "/:required/:optional?",
+      matches: nil,
+      expected: &Matches{
+        Params: map[string]string{"required": "foo", "optional": "bar"},
+      },
+    },
+    {
+      name:    "Mixed required and optional params - missing optional",
+      url:     "/foo",
+      route:   "/:required/:optional?",
+      matches: nil,
+      expected: &Matches{
+        Params: map[string]string{"required": "foo", "optional": ""},
+      },
+    },
 
 		// Test with pre-existing matches
 		{
@@ -291,18 +282,6 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 					"first":    "foo",
 					"second":   "bar",
 				},
-			},
-		},
-
-		// Wildcard anonymous rest
-		{
-			name:    "Anonymous wildcard rest",
-			url:     "/static/css/main.css",
-			route:   "/static/*",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{},
-				Rest:   "/css/main.css",
 			},
 		},
 
@@ -338,17 +317,6 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 				Params: map[string]string{"version": ""},
 			},
 		},
-
-		// JavaScript-specific behavior tests
-		{
-			name:    "Empty string should be handled as undefined for optional rest",
-			url:     "/user",
-			route:   "/user/:id*",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"id": ""},
-			},
-		},
 		{
 			name:    "Multiple slashes in URL should be normalized",
 			url:     "//user//123//",
@@ -368,33 +336,6 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			},
 		},
 		{
-			name:    "Special characters in param names",
-			url:     "/user/123",
-			route:   "/user/:user_id",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"user_id": "123"},
-			},
-		},
-		{
-			name:    "Param with numbers",
-			url:     "/api/v1",
-			route:   "/api/:version1",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"version1": "v1"},
-			},
-		},
-		{
-			name:    "Rest param with single character",
-			url:     "/a/b",
-			route:   "/:x+",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"x": "a/b"},
-			},
-		},
-		{
 			name:    "Complex URL encoding in rest params",
 			url:     "/files/folder%2Fsubfolder/file%20name.txt",
 			route:   "/files/:path+",
@@ -404,48 +345,12 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			},
 		},
 		{
-			name:    "Question mark in URL (not query param)",
-			url:     "/search/what%3F",
+			name:    "Special characters encoded in URL",
+			url:     "/search/query%3F%2B%23%26test",
 			route:   "/search/:query",
 			matches: nil,
 			expected: &Matches{
-				Params: map[string]string{"query": "what?"},
-			},
-		},
-		{
-			name:    "Plus sign in URL",
-			url:     "/math/1%2B1",
-			route:   "/math/:expression",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"expression": "1+1"},
-			},
-		},
-		{
-			name:    "Hash in URL (encoded)",
-			url:     "/tag/%23javascript",
-			route:   "/tag/:name",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"name": "#javascript"},
-			},
-		},
-		{
-			name:    "Ampersand in URL",
-			url:     "/search/cats%26dogs",
-			route:   "/search/:query",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"query": "cats&dogs"},
-			},
-		},
-		{
-			name:    "Unicode characters",
-			url:     "/user/José",
-			route:   "/user/:name",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"name": "José"},
+				Params: map[string]string{"query": "query?+#&test"},
 			},
 		},
 		{
@@ -455,15 +360,6 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			matches: nil,
 			expected: &Matches{
 				Params: map[string]string{"name": "José"},
-			},
-		},
-		{
-			name:    "Very long param",
-			url:     "/data/" + strings.Repeat("a", 1000),
-			route:   "/data/:content",
-			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"content": strings.Repeat("a", 1000)},
 			},
 		},
 		{
@@ -485,28 +381,32 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 				Rest:   "/anything/goes/here",
 			},
 		},
+	}
+
+	// URL decoding error handling tests
+	urlDecodingTests := []struct {
+		name     string
+		url      string
+		route    string
+		matches  *Matches
+	}{
 		{
-			name:    "Multiple consecutive optional params",
-			url:     "/a/b",
-			route:   "/:first?/:second?/:third?/:fourth?",
+			name:    "Malformed percent encoding in simple param - should not crash",
+			url:     "/user/test%",
+			route:   "/user/:id",
 			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{
-					"first":  "a",
-					"second": "b",
-					"third":  "",
-					"fourth": "",
-				},
-			},
 		},
 		{
-			name:    "Zero-width param names (edge case)",
-			url:     "/test",
-			route:   "/:?",
+			name:    "Malformed percent encoding in rest param - should not crash",
+			url:     "/files/test%/file",
+			route:   "/files/:path+",
 			matches: nil,
-			expected: &Matches{
-				Params: map[string]string{"": "test"},
-			},
+		},
+		{
+			name:    "Invalid unicode sequence - should not crash",
+			url:     "/user/test%C3",
+			route:   "/user/:id",
+			matches: nil,
 		},
 	}
 
@@ -546,33 +446,22 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			}
 		})
 	}
-}
 
-// Test to document expected JavaScript behavior for debugging
-func TestJavaScriptBehaviorReference(t *testing.T) {
-	// These tests document what the JavaScript version should return
-	// for direct comparison with Go implementation
-
-	t.Run("JavaScript rest param behavior", func(t *testing.T) {
-		// In JavaScript: url.slice(i).map(decodeURIComponent).join('/') || undefined
-		// This means for "/user/foo/bar" with route "/user/:id*":
-		// - url = ["user", "foo", "bar"]
-		// - route = ["user", ":id*"]
-		// - At i=1: url.slice(1) = ["foo", "bar"]
-		// - joined: "foo/bar"
-		// - Result: {params: {id: "foo/bar"}}
-
-		t.Logf("Expected: rest params should join ALL remaining segments with '/'")
-		t.Logf("Go issue: likely only taking first segment instead of all remaining")
-	})
-
-	t.Run("JavaScript URL encoding behavior", func(t *testing.T) {
-		// JavaScript uses decodeURIComponent on each segment
-		// For rest params, it decodes EACH segment then joins with '/'
-
-		t.Logf("Expected: each URL segment should be decoded separately")
-		t.Logf("For rest params: decode each segment, then join with '/'")
-	})
+	// Test URL decoding error handling - these should not crash
+	for _, tt := range urlDecodingTests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The main requirement is that this doesn't crash
+			// We don't care about the exact return value as long as it doesn't panic
+			result := preactIsoUrlPatternMatch(tt.url, tt.route, tt.matches)
+			// Should either work or return nil, but not crash
+			if result != nil {
+				// If it returns a result, just verify it has params
+				if result.Params == nil {
+					t.Errorf("Result should have non-nil Params map")
+				}
+			}
+		})
+	}
 }
 
 // Debug helper to trace execution
@@ -638,29 +527,6 @@ func TestFilterEmpty(t *testing.T) {
 			}
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("Expected %+v, got %+v", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestMax(t *testing.T) {
-	tests := []struct {
-		name     string
-		a, b     int
-		expected int
-	}{
-		{"a greater", 5, 3, 5},
-		{"b greater", 3, 5, 5},
-		{"equal", 4, 4, 4},
-		{"negative", -1, -5, -1},
-		{"zero", 0, 0, 0},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := max(tt.a, tt.b)
-			if result != tt.expected {
-				t.Errorf("max(%d, %d) = %d, expected %d", tt.a, tt.b, result, tt.expected)
 			}
 		})
 	}

--- a/polyglot-utils/go/preact_iso_url_pattern_test.go
+++ b/polyglot-utils/go/preact_iso_url_pattern_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 )
 
+// Note 1: This is different from JS implementation. Here it is empty string and not nil
+// This was intentionally implemented this way, but we can change if it's a problem
+
 func TestPreactIsoUrlPatternMatch(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -60,9 +63,19 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			},
 		},
 		{
+			name:    "Rest segment - match multiple segments",
+			url:     "/user/foo/bar/baz",
+			route:   "/user/*",
+			matches: nil,
+			expected: &Matches{
+				Params: map[string]string{},
+				Rest:   "/foo/bar/baz",
+			},
+		},
+		{
 			name:     "Rest segment - no match",
-			url:      "/",
-			route:    "/user/:id/*",
+			url:      "/user",
+			route:    "/user/*",
 			matches:  nil,
 			expected: nil,
 		},
@@ -88,6 +101,13 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 				Rest:   "/foo/bar/bob",
 			},
 		},
+		{
+			name:     "Param with rest - no match",
+			url:      "/",
+			route:    "/user/:id/*",
+			matches:  nil,
+			expected: nil,
+		},
 
 		// Optional param tests
 		{
@@ -96,6 +116,7 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			route:   "/user/:id?",
 			matches: nil,
 			expected: &Matches{
+				// Check "Note 1" at the top of the file
 				Params: map[string]string{"id": ""},
 			},
 		},
@@ -114,6 +135,7 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			route:   "/user/:id*",
 			matches: nil,
 			expected: &Matches{
+				// Check "Note 1" at the top of the file
 				Params: map[string]string{"id": ""},
 			},
 		},
@@ -125,6 +147,13 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			expected: &Matches{
 				Params: map[string]string{"id": "foo/bar"},
 			},
+		},
+		{
+			name:     "Optional param - no match base",
+			url:      "/",
+			route:    "/user/:id*",
+			matches:  nil,
+			expected: nil,
 		},
 
 		// Required rest param tests (/:x+)
@@ -175,6 +204,7 @@ func TestPreactIsoUrlPatternMatch(t *testing.T) {
 			},
 		},
 
+		// Additional tests that are not in test/node/router-match.test.js
 		// URL encoding tests
 		{
 			name:    "URL encoded param",

--- a/polyglot-utils/php/README.md
+++ b/polyglot-utils/php/README.md
@@ -1,0 +1,67 @@
+# PHP Implementation
+
+URL pattern matching utility for PHP servers.
+
+## Setup
+
+Code tested on PHP 8.3.x.
+
+```sh
+php --version  # Ensure PHP 7.0+ is available
+# No third party dependencies needed. Just run the tests or use the function directly
+```
+
+## Running Tests
+
+```sh
+php test_preact_iso_url_pattern.php
+```
+
+## Usage
+
+```php
+<?php
+require_once 'preact-iso-url-pattern.php';
+
+$matches = preactIsoUrlPatternMatch("/users/test%40example.com/posts", "/users/:userId/posts");
+if ($matches) {
+    echo "User ID: " . $matches['params']->userId . "\n";  // Output: test@example.com
+}
+?>
+```
+
+## Function Signature
+
+```php
+function preactIsoUrlPatternMatch($url, $route, $matches = null): array|null
+```
+
+### Parameters
+
+- `$url` (string): The URL path to match
+- `$route` (string): The route pattern with parameters
+- `$matches` (array, optional): Pre-existing matches array to extend
+
+### Return Value
+
+Returns an array on success, or `null` if no match:
+
+```php
+[
+    'params' => (object)['userId' => '123'],
+    'userId' => '123',
+    'rest' => '/additional/path'  // Optional
+]
+```
+
+**Note**: The `params` property is a PHP object (stdClass) to maintain consistency with JSON serialization, while the outer structure is an array.
+
+## Route Patterns
+
+| Pattern | Description | Example Result |
+|---------|-------------|----------------|
+| `/users/:id` | Named parameter | `['params' => (object)['id' => '123'], 'id' => '123']` |
+| `/users/:id?` | Optional parameter | `['params' => (object)['id' => null], 'id' => null]` |
+| `/files/:path+` | Required rest parameter | `['params' => (object)['path' => 'docs/readme.txt']]` |
+| `/static/:path*` | Optional rest parameter | `['params' => (object)['path' => 'css/main.css']]` |
+| `/static/*` | Anonymous wildcard | `['params' => (object)[], 'rest' => '/images/logo.png']` |

--- a/polyglot-utils/php/preact-iso-url-pattern.php
+++ b/polyglot-utils/php/preact-iso-url-pattern.php
@@ -6,11 +6,11 @@ function safeUrldecode($str) {
     if ($str === null || $str === '') {
         return $str;
     }
-    
+
     // urldecode in PHP generally doesn't throw exceptions,
     // but we can add validation for malformed percent encoding
     $decoded = urldecode($str);
-    
+
     // If the original contained a % but decoding didn't change much,
     // it might be malformed, but PHP's urldecode is quite tolerant
     return $decoded;
@@ -32,7 +32,7 @@ function preactIsoUrlPatternMatch($url, $route, $matches = null) {
 
         // segment match:
         if (!$m && $param === $val) continue;
-        
+
         // /foo/* match
         if (!$m && $val && $flag == '*') {
             $decodedParts = array_map('safeUrldecode', array_slice($url, $i));

--- a/polyglot-utils/php/preact-iso-url-pattern.php
+++ b/polyglot-utils/php/preact-iso-url-pattern.php
@@ -1,0 +1,75 @@
+<?php
+// Run program: php preact-iso-url-pattern.php
+
+// Safe URL decode function with error handling
+function safeUrldecode($str) {
+    if ($str === null || $str === '') {
+        return $str;
+    }
+    
+    // urldecode in PHP generally doesn't throw exceptions,
+    // but we can add validation for malformed percent encoding
+    $decoded = urldecode($str);
+    
+    // If the original contained a % but decoding didn't change much,
+    // it might be malformed, but PHP's urldecode is quite tolerant
+    return $decoded;
+}
+
+function preactIsoUrlPatternMatch($url, $route, $matches = null) {
+    if ($matches === null) {
+        $matches = ['params' => (object)[]];
+    }
+    $url = array_values(array_filter(explode('/', $url)));
+    $route = array_values(array_filter(explode('/', $route ?? '')));
+
+    for ($i = 0; $i < max(count($url), count($route)); $i++) {
+        preg_match('/^(:?)(.*?)([+*?]?)$/', $route[$i] ?? '', $parts);
+        $m = $parts[1] ?? '';
+        $param = $parts[2] ?? '';
+        $flag = $parts[3] ?? '';
+        $val = $url[$i] ?? null;
+
+        // segment match:
+        if (!$m && $param === $val) continue;
+        
+        // /foo/* match
+        if (!$m && $val && $flag == '*') {
+            $decodedParts = array_map('safeUrldecode', array_slice($url, $i));
+            $matches['rest'] = '/' . implode('/', $decodedParts);
+            break;
+        }
+
+        // segment mismatch / missing required field:
+        if (!$m || (!$val && $flag != '?' && $flag != '*')) {
+            return null;
+        }
+        $rest = $flag == '+' || $flag == '*';
+
+        // rest (+/*) match:
+        if ($rest) {
+            $decodedParts = array_map('safeUrldecode', array_slice($url, $i));
+            $val = implode('/', $decodedParts) ?: null;
+        }
+        // normal/optional field:
+        elseif ($val) {
+            $val = safeUrldecode($url[$i]);
+        }
+
+        $matches['params']->$param = $val;
+        if (!isset($matches[$param])) {
+            $matches[$param] = $val;
+        }
+
+        if ($rest) break;
+    }
+
+    return $matches;
+}
+// Example usage:
+// var_dump(preactIsoUrlPatternMatch("/foo/bar%20baz", "/foo/:param"));
+// var_dump(preactIsoUrlPatternMatch("/foo/bar/baz", "/foo/*"));
+// var_dump(preactIsoUrlPatternMatch("/foo", "/foo/:param?"));
+// var_dump(preactIsoUrlPatternMatch("/foo/bar", "/bar/:param"));
+// var_dump(preactIsoUrlPatternMatch('/users/test%40example.com/posts', '/users/:userId/posts'));
+?>

--- a/polyglot-utils/php/test_preact_iso_url_pattern.php
+++ b/polyglot-utils/php/test_preact_iso_url_pattern.php
@@ -71,6 +71,7 @@ class TestPreactIsoUrlPatternMatch {
     
     // Test methods start here
     
+    // Base route tests
     public function test_base_route_exact_match() {
         $result = preactIsoUrlPatternMatch("/", "/");
         $expected = ['params' => (object)[]];
@@ -82,6 +83,7 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertNull($result);
     }
     
+    // Param route tests
     public function test_param_route_match() {
         $result = preactIsoUrlPatternMatch("/user/2", "/user/:id");
         $expected = ['params' => (object)['id' => '2'], 'id' => '2'];
@@ -93,6 +95,7 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertNull($result);
     }
     
+    // Rest segment tests
     public function test_rest_segment_match() {
         $result = preactIsoUrlPatternMatch("/user/foo", "/user/*");
         $expected = ['params' => (object)[], 'rest' => '/foo'];
@@ -115,6 +118,7 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertNull($result);
     }
     
+    // Param route with rest segment
     public function test_param_with_rest_single_segment() {
         $result = preactIsoUrlPatternMatch("/user/2/foo", "/user/:id/*");
         $expected = ['params' => (object)['id' => '2'], 'id' => '2', 'rest' => '/foo'];
@@ -127,6 +131,12 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertEqual($expected, $result);
     }
     
+    public function test_param_with_rest_no_match() {
+        $result = preactIsoUrlPatternMatch("/", "/user/:id/*");
+        $this->assertNull($result);
+    }
+    
+    // Optional param tests
     public function test_optional_param_empty() {
         $result = preactIsoUrlPatternMatch("/user", "/user/:id?");
         $expected = ['params' => (object)['id' => null], 'id' => null];
@@ -138,6 +148,7 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertNull($result);
     }
     
+    // Optional rest param tests (/:x*)
     public function test_optional_rest_param_empty() {
         $result = preactIsoUrlPatternMatch("/user", "/user/:id*");
         $expected = ['params' => (object)['id' => null], 'id' => null];
@@ -150,6 +161,12 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertEqual($expected, $result);
     }
     
+    public function test_optional_param_no_match_base_duplicate() {
+        $result = preactIsoUrlPatternMatch("/", "/user/:id*");
+        $this->assertNull($result);
+    }
+    
+    // Required rest param tests (/:x+)
     public function test_required_rest_param_single_segment() {
         $result = preactIsoUrlPatternMatch("/user/foo", "/user/:id+");
         $expected = ['params' => (object)['id' => 'foo'], 'id' => 'foo'];
@@ -172,12 +189,15 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertNull($result);
     }
     
+    // Leading/trailing slashes
     public function test_leading_trailing_slashes() {
         $result = preactIsoUrlPatternMatch("/about-late/_SEGMENT1_/_SEGMENT2_/", "/about-late/:seg1/:seg2/");
         $expected = ['params' => (object)['seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_'], 'seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_'];
         $this->assertEqual($expected, $result);
     }
     
+    // Additional tests that are not in test/node/router-match.test.js
+    // URL encoding tests
     public function test_url_encoded_param() {
         $result = preactIsoUrlPatternMatch("/foo/bar%20baz", "/foo/:param");
         $expected = ['params' => (object)['param' => 'bar baz'], 'param' => 'bar baz'];
@@ -190,12 +210,14 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertEqual($expected, $result);
     }
     
+    // Complex rest segment with encoding
     public function test_rest_segment_with_encoded_parts() {
         $result = preactIsoUrlPatternMatch("/api/path/with%20spaces/and%2Fslashes", "/api/:path+");
         $expected = ['params' => (object)['path' => 'path/with spaces/and/slashes'], 'path' => 'path/with spaces/and/slashes'];
         $this->assertEqual($expected, $result);
     }
     
+    // Edge cases
     public function test_empty_route() {
         $result = preactIsoUrlPatternMatch("/foo", "");
         $this->assertNull($result);
@@ -204,12 +226,6 @@ class TestPreactIsoUrlPatternMatch {
     public function test_empty_url_with_param() {
         $result = preactIsoUrlPatternMatch("", "/:param");
         $this->assertNull($result);
-    }
-    
-    public function test_multiple_optional_params() {
-        $result = preactIsoUrlPatternMatch("/foo", "/:a?/:b?/:c?");
-        $expected = ['params' => (object)['a' => 'foo', 'b' => null, 'c' => null], 'a' => 'foo', 'b' => null, 'c' => null];
-        $this->assertEqual($expected, $result);
     }
     
     public function test_mixed_required_and_optional_params() {
@@ -224,6 +240,7 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertEqual($expected, $result);
     }
     
+    // Test with pre-existing matches
     public function test_pre_existing_matches_object() {
         $matches = ['params' => (object)['existing' => 'value']];
         $result = preactIsoUrlPatternMatch("/foo/bar", "/:first/:second", $matches);
@@ -231,12 +248,8 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertEqual($expected, $result);
     }
     
-    public function test_anonymous_wildcard_rest() {
-        $result = preactIsoUrlPatternMatch("/static/css/main.css", "/static/*");
-        $expected = ['params' => (object)[], 'rest' => '/css/main.css'];
-        $this->assertEqual($expected, $result);
-    }
-    
+
+    // Complex nested paths
     public function test_complex_nested_path_with_multiple_params() {
         $result = preactIsoUrlPatternMatch("/api/v1/users/123/posts/456/comments", "/api/:version/users/:userId/posts/:postId/comments");
         $expected = [
@@ -256,13 +269,7 @@ class TestPreactIsoUrlPatternMatch {
         $expected = ['params' => (object)['version' => null], 'version' => null];
         $this->assertEqual($expected, $result);
     }
-    
-    public function test_empty_string_should_be_handled_as_undefined_for_optional_rest() {
-        $result = preactIsoUrlPatternMatch("/user", "/user/:id*");
-        $expected = ['params' => (object)['id' => null], 'id' => null];
-        $this->assertEqual($expected, $result);
-    }
-    
+
     public function test_multiple_slashes_in_url_should_be_normalized() {
         $result = preactIsoUrlPatternMatch("//user//123//", "/user/:id");
         $expected = ['params' => (object)['id' => '123'], 'id' => '123'];
@@ -274,74 +281,29 @@ class TestPreactIsoUrlPatternMatch {
         $expected = ['params' => (object)['id' => '123'], 'id' => '123'];
         $this->assertEqual($expected, $result);
     }
-    
-    public function test_special_characters_in_param_names() {
-        $result = preactIsoUrlPatternMatch("/user/123", "/user/:user_id");
-        $expected = ['params' => (object)['user_id' => '123'], 'user_id' => '123'];
-        $this->assertEqual($expected, $result);
-    }
-    
-    public function test_param_with_numbers() {
-        $result = preactIsoUrlPatternMatch("/api/v1", "/api/:version1");
-        $expected = ['params' => (object)['version1' => 'v1'], 'version1' => 'v1'];
-        $this->assertEqual($expected, $result);
-    }
-    
-    public function test_rest_param_with_single_character() {
-        $result = preactIsoUrlPatternMatch("/a/b", "/:x+");
-        $expected = ['params' => (object)['x' => 'a/b'], 'x' => 'a/b'];
-        $this->assertEqual($expected, $result);
-    }
-    
+
+
+    // Additional URL encoding tests
     public function test_complex_url_encoding_in_rest_params() {
         $result = preactIsoUrlPatternMatch("/files/folder%2Fsubfolder/file%20name.txt", "/files/:path+");
         $expected = ['params' => (object)['path' => 'folder/subfolder/file name.txt'], 'path' => 'folder/subfolder/file name.txt'];
         $this->assertEqual($expected, $result);
     }
     
-    public function test_question_mark_in_url_not_query_param() {
-        $result = preactIsoUrlPatternMatch("/search/what%3F", "/search/:query");
-        $expected = ['params' => (object)['query' => 'what?'], 'query' => 'what?'];
+    public function test_special_characters_encoded_in_url() {
+        $result = preactIsoUrlPatternMatch("/search/query%3F%2B%23%26test", "/search/:query");
+        $expected = ['params' => (object)['query' => 'query?+#&test'], 'query' => 'query?+#&test'];
         $this->assertEqual($expected, $result);
     }
     
-    public function test_plus_sign_in_url() {
-        $result = preactIsoUrlPatternMatch("/math/1%2B1", "/math/:expression");
-        $expected = ['params' => (object)['expression' => '1+1'], 'expression' => '1+1'];
-        $this->assertEqual($expected, $result);
-    }
-    
-    public function test_hash_in_url_encoded() {
-        $result = preactIsoUrlPatternMatch("/tag/%23javascript", "/tag/:name");
-        $expected = ['params' => (object)['name' => '#javascript'], 'name' => '#javascript'];
-        $this->assertEqual($expected, $result);
-    }
-    
-    public function test_ampersand_in_url() {
-        $result = preactIsoUrlPatternMatch("/search/cats%26dogs", "/search/:query");
-        $expected = ['params' => (object)['query' => 'cats&dogs'], 'query' => 'cats&dogs'];
-        $this->assertEqual($expected, $result);
-    }
-    
-    public function test_unicode_characters() {
-        $result = preactIsoUrlPatternMatch("/user/José", "/user/:name");
-        $expected = ['params' => (object)['name' => 'José'], 'name' => 'José'];
-        $this->assertEqual($expected, $result);
-    }
+
     
     public function test_unicode_characters_encoded() {
         $result = preactIsoUrlPatternMatch("/user/Jos%C3%A9", "/user/:name");
         $expected = ['params' => (object)['name' => 'José'], 'name' => 'José'];
         $this->assertEqual($expected, $result);
     }
-    
-    public function test_very_long_param() {
-        $long_content = str_repeat('a', 1000);
-        $result = preactIsoUrlPatternMatch("/data/$long_content", "/data/:content");
-        $expected = ['params' => (object)['content' => $long_content], 'content' => $long_content];
-        $this->assertEqual($expected, $result);
-    }
-    
+
     public function test_empty_segments_in_middle_of_url() {
         $result = preactIsoUrlPatternMatch("/api//v1//users", "/api/v1/users");
         $expected = ['params' => (object)[]];
@@ -354,23 +316,7 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertEqual($expected, $result);
     }
     
-    public function test_multiple_consecutive_optional_params() {
-        $result = preactIsoUrlPatternMatch("/a/b", "/:first?/:second?/:third?/:fourth?");
-        $expected = [
-            'params' => (object)['first' => 'a', 'second' => 'b', 'third' => null, 'fourth' => null],
-            'first' => 'a', 'second' => 'b', 'third' => null, 'fourth' => null
-        ];
-        $this->assertEqual($expected, $result);
-    }
-    
-    public function test_zero_width_param_names_edge_case() {
-        $result = preactIsoUrlPatternMatch("/test", "/:?");
-        $expected = ['params' => (object)['' => 'test'], '' => 'test'];
-        $this->assertEqual($expected, $result);
-    }
-    
     // URL decoding error handling tests
-    
     public function test_malformed_percent_encoding_simple_param() {
         // Test malformed percent encoding in simple param - should not crash
         $result = preactIsoUrlPatternMatch("/user/test%", "/user/:id");

--- a/polyglot-utils/php/test_preact_iso_url_pattern.php
+++ b/polyglot-utils/php/test_preact_iso_url_pattern.php
@@ -99,7 +99,18 @@ class TestPreactIsoUrlPatternMatch {
         $this->assertEqual($expected, $result);
     }
     
+    public function test_rest_segment_match_multiple_segments() {
+        $result = preactIsoUrlPatternMatch("/user/foo/bar/baz", "/user/*");
+        $expected = ['params' => (object)[], 'rest' => '/foo/bar/baz'];
+        $this->assertEqual($expected, $result);
+    }
+    
     public function test_rest_segment_no_match() {
+        $result = preactIsoUrlPatternMatch("/user", "/user/*");
+        $this->assertNull($result);
+    }
+    
+    public function test_rest_segment_no_match_different_case() {
         $result = preactIsoUrlPatternMatch("/", "/user/:id/*");
         $this->assertNull($result);
     }

--- a/polyglot-utils/php/test_preact_iso_url_pattern.php
+++ b/polyglot-utils/php/test_preact_iso_url_pattern.php
@@ -1,0 +1,390 @@
+<?php
+/**
+ * Test suite for preact-iso-url-pattern.php - ported from Go tests
+ * Run with: php test_preact_iso_url_pattern.php
+ */
+
+require_once 'preact-iso-url-pattern.php';
+
+class TestPreactIsoUrlPatternMatch {
+    private $tests = 0;
+    private $passed = 0;
+    private $failed = 0;
+    
+    public function run() {
+        echo "Running PHP tests for preact-iso-url-pattern...\n\n";
+        
+        // Run all test methods
+        $methods = get_class_methods($this);
+        foreach ($methods as $method) {
+            if (strpos($method, 'test_') === 0) {
+                $this->runTest($method);
+            }
+        }
+        
+        echo "\n" . str_repeat("=", 60) . "\n";
+        echo "Test Results: {$this->passed} passed, {$this->failed} failed, {$this->tests} total\n";
+        
+        if ($this->failed > 0) {
+            exit(1);
+        }
+        echo "All tests passed!\n";
+    }
+    
+    private function runTest($methodName) {
+        $this->tests++;
+        try {
+            $this->$methodName();
+            $this->passed++;
+            echo ".";
+        } catch (Exception $e) {
+            $this->failed++;
+            echo "F";
+            echo "\nFAILED: $methodName - " . $e->getMessage() . "\n";
+        }
+    }
+    
+    private function assertEqual($expected, $actual, $message = '') {
+        // Use JSON comparison for deep equality check (works for arrays and objects)
+        $expectedJson = json_encode($expected);
+        $actualJson = json_encode($actual);
+        
+        if ($expectedJson !== $actualJson) {
+            $expectedStr = json_encode($expected, JSON_PRETTY_PRINT);
+            $actualStr = json_encode($actual, JSON_PRETTY_PRINT);
+            throw new Exception("Expected:\n$expectedStr\nGot:\n$actualStr\n$message");
+        }
+    }
+    
+    private function assertNull($actual, $message = '') {
+        if ($actual !== null) {
+            $actualStr = json_encode($actual, JSON_PRETTY_PRINT);
+            throw new Exception("Expected null, got:\n$actualStr\n$message");
+        }
+    }
+    
+    private function assertNotNull($actual, $message = '') {
+        if ($actual === null) {
+            throw new Exception("Expected non-null value, got null\n$message");
+        }
+    }
+    
+    // Test methods start here
+    
+    public function test_base_route_exact_match() {
+        $result = preactIsoUrlPatternMatch("/", "/");
+        $expected = ['params' => (object)[]];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_base_route_no_match() {
+        $result = preactIsoUrlPatternMatch("/user/1", "/");
+        $this->assertNull($result);
+    }
+    
+    public function test_param_route_match() {
+        $result = preactIsoUrlPatternMatch("/user/2", "/user/:id");
+        $expected = ['params' => (object)['id' => '2'], 'id' => '2'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_param_route_no_match() {
+        $result = preactIsoUrlPatternMatch("/", "/user/:id");
+        $this->assertNull($result);
+    }
+    
+    public function test_rest_segment_match() {
+        $result = preactIsoUrlPatternMatch("/user/foo", "/user/*");
+        $expected = ['params' => (object)[], 'rest' => '/foo'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_rest_segment_no_match() {
+        $result = preactIsoUrlPatternMatch("/", "/user/:id/*");
+        $this->assertNull($result);
+    }
+    
+    public function test_param_with_rest_single_segment() {
+        $result = preactIsoUrlPatternMatch("/user/2/foo", "/user/:id/*");
+        $expected = ['params' => (object)['id' => '2'], 'id' => '2', 'rest' => '/foo'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_param_with_rest_multiple_segments() {
+        $result = preactIsoUrlPatternMatch("/user/2/foo/bar/bob", "/user/:id/*");
+        $expected = ['params' => (object)['id' => '2'], 'id' => '2', 'rest' => '/foo/bar/bob'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_optional_param_empty() {
+        $result = preactIsoUrlPatternMatch("/user", "/user/:id?");
+        $expected = ['params' => (object)['id' => null], 'id' => null];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_optional_param_no_match_base() {
+        $result = preactIsoUrlPatternMatch("/", "/user/:id?");
+        $this->assertNull($result);
+    }
+    
+    public function test_optional_rest_param_empty() {
+        $result = preactIsoUrlPatternMatch("/user", "/user/:id*");
+        $expected = ['params' => (object)['id' => null], 'id' => null];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_optional_rest_param_with_segments() {
+        $result = preactIsoUrlPatternMatch("/user/foo/bar", "/user/:id*");
+        $expected = ['params' => (object)['id' => 'foo/bar'], 'id' => 'foo/bar'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_required_rest_param_single_segment() {
+        $result = preactIsoUrlPatternMatch("/user/foo", "/user/:id+");
+        $expected = ['params' => (object)['id' => 'foo'], 'id' => 'foo'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_required_rest_param_multiple_segments() {
+        $result = preactIsoUrlPatternMatch("/user/foo/bar", "/user/:id+");
+        $expected = ['params' => (object)['id' => 'foo/bar'], 'id' => 'foo/bar'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_required_rest_param_empty_should_fail() {
+        $result = preactIsoUrlPatternMatch("/user", "/user/:id+");
+        $this->assertNull($result);
+    }
+    
+    public function test_required_rest_param_root_mismatch() {
+        $result = preactIsoUrlPatternMatch("/", "/user/:id+");
+        $this->assertNull($result);
+    }
+    
+    public function test_leading_trailing_slashes() {
+        $result = preactIsoUrlPatternMatch("/about-late/_SEGMENT1_/_SEGMENT2_/", "/about-late/:seg1/:seg2/");
+        $expected = ['params' => (object)['seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_'], 'seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_url_encoded_param() {
+        $result = preactIsoUrlPatternMatch("/foo/bar%20baz", "/foo/:param");
+        $expected = ['params' => (object)['param' => 'bar baz'], 'param' => 'bar baz'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_url_encoded_email_in_param() {
+        $result = preactIsoUrlPatternMatch("/users/test%40example.com/posts", "/users/:userId/posts");
+        $expected = ['params' => (object)['userId' => 'test@example.com'], 'userId' => 'test@example.com'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_rest_segment_with_encoded_parts() {
+        $result = preactIsoUrlPatternMatch("/api/path/with%20spaces/and%2Fslashes", "/api/:path+");
+        $expected = ['params' => (object)['path' => 'path/with spaces/and/slashes'], 'path' => 'path/with spaces/and/slashes'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_empty_route() {
+        $result = preactIsoUrlPatternMatch("/foo", "");
+        $this->assertNull($result);
+    }
+    
+    public function test_empty_url_with_param() {
+        $result = preactIsoUrlPatternMatch("", "/:param");
+        $this->assertNull($result);
+    }
+    
+    public function test_multiple_optional_params() {
+        $result = preactIsoUrlPatternMatch("/foo", "/:a?/:b?/:c?");
+        $expected = ['params' => (object)['a' => 'foo', 'b' => null, 'c' => null], 'a' => 'foo', 'b' => null, 'c' => null];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_mixed_required_and_optional_params() {
+        $result = preactIsoUrlPatternMatch("/foo/bar", "/:required/:optional?");
+        $expected = ['params' => (object)['required' => 'foo', 'optional' => 'bar'], 'required' => 'foo', 'optional' => 'bar'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_mixed_required_and_optional_params_missing_optional() {
+        $result = preactIsoUrlPatternMatch("/foo", "/:required/:optional?");
+        $expected = ['params' => (object)['required' => 'foo', 'optional' => null], 'required' => 'foo', 'optional' => null];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_pre_existing_matches_object() {
+        $matches = ['params' => (object)['existing' => 'value']];
+        $result = preactIsoUrlPatternMatch("/foo/bar", "/:first/:second", $matches);
+        $expected = ['params' => (object)['existing' => 'value', 'first' => 'foo', 'second' => 'bar'], 'first' => 'foo', 'second' => 'bar'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_anonymous_wildcard_rest() {
+        $result = preactIsoUrlPatternMatch("/static/css/main.css", "/static/*");
+        $expected = ['params' => (object)[], 'rest' => '/css/main.css'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_complex_nested_path_with_multiple_params() {
+        $result = preactIsoUrlPatternMatch("/api/v1/users/123/posts/456/comments", "/api/:version/users/:userId/posts/:postId/comments");
+        $expected = [
+            'params' => (object)['version' => 'v1', 'userId' => '123', 'postId' => '456'],
+            'version' => 'v1', 'userId' => '123', 'postId' => '456'
+        ];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_route_longer_than_url_required_param_missing() {
+        $result = preactIsoUrlPatternMatch("/api", "/api/:version/:resource");
+        $this->assertNull($result);
+    }
+    
+    public function test_route_longer_than_url_optional_param() {
+        $result = preactIsoUrlPatternMatch("/api", "/api/:version?");
+        $expected = ['params' => (object)['version' => null], 'version' => null];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_empty_string_should_be_handled_as_undefined_for_optional_rest() {
+        $result = preactIsoUrlPatternMatch("/user", "/user/:id*");
+        $expected = ['params' => (object)['id' => null], 'id' => null];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_multiple_slashes_in_url_should_be_normalized() {
+        $result = preactIsoUrlPatternMatch("//user//123//", "/user/:id");
+        $expected = ['params' => (object)['id' => '123'], 'id' => '123'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_route_with_multiple_slashes() {
+        $result = preactIsoUrlPatternMatch("/user/123", "//user//:id//");
+        $expected = ['params' => (object)['id' => '123'], 'id' => '123'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_special_characters_in_param_names() {
+        $result = preactIsoUrlPatternMatch("/user/123", "/user/:user_id");
+        $expected = ['params' => (object)['user_id' => '123'], 'user_id' => '123'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_param_with_numbers() {
+        $result = preactIsoUrlPatternMatch("/api/v1", "/api/:version1");
+        $expected = ['params' => (object)['version1' => 'v1'], 'version1' => 'v1'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_rest_param_with_single_character() {
+        $result = preactIsoUrlPatternMatch("/a/b", "/:x+");
+        $expected = ['params' => (object)['x' => 'a/b'], 'x' => 'a/b'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_complex_url_encoding_in_rest_params() {
+        $result = preactIsoUrlPatternMatch("/files/folder%2Fsubfolder/file%20name.txt", "/files/:path+");
+        $expected = ['params' => (object)['path' => 'folder/subfolder/file name.txt'], 'path' => 'folder/subfolder/file name.txt'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_question_mark_in_url_not_query_param() {
+        $result = preactIsoUrlPatternMatch("/search/what%3F", "/search/:query");
+        $expected = ['params' => (object)['query' => 'what?'], 'query' => 'what?'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_plus_sign_in_url() {
+        $result = preactIsoUrlPatternMatch("/math/1%2B1", "/math/:expression");
+        $expected = ['params' => (object)['expression' => '1+1'], 'expression' => '1+1'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_hash_in_url_encoded() {
+        $result = preactIsoUrlPatternMatch("/tag/%23javascript", "/tag/:name");
+        $expected = ['params' => (object)['name' => '#javascript'], 'name' => '#javascript'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_ampersand_in_url() {
+        $result = preactIsoUrlPatternMatch("/search/cats%26dogs", "/search/:query");
+        $expected = ['params' => (object)['query' => 'cats&dogs'], 'query' => 'cats&dogs'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_unicode_characters() {
+        $result = preactIsoUrlPatternMatch("/user/José", "/user/:name");
+        $expected = ['params' => (object)['name' => 'José'], 'name' => 'José'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_unicode_characters_encoded() {
+        $result = preactIsoUrlPatternMatch("/user/Jos%C3%A9", "/user/:name");
+        $expected = ['params' => (object)['name' => 'José'], 'name' => 'José'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_very_long_param() {
+        $long_content = str_repeat('a', 1000);
+        $result = preactIsoUrlPatternMatch("/data/$long_content", "/data/:content");
+        $expected = ['params' => (object)['content' => $long_content], 'content' => $long_content];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_empty_segments_in_middle_of_url() {
+        $result = preactIsoUrlPatternMatch("/api//v1//users", "/api/v1/users");
+        $expected = ['params' => (object)[]];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_route_with_only_wildcards() {
+        $result = preactIsoUrlPatternMatch("/anything/goes/here", "*");
+        $expected = ['params' => (object)[], 'rest' => '/anything/goes/here'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_multiple_consecutive_optional_params() {
+        $result = preactIsoUrlPatternMatch("/a/b", "/:first?/:second?/:third?/:fourth?");
+        $expected = [
+            'params' => (object)['first' => 'a', 'second' => 'b', 'third' => null, 'fourth' => null],
+            'first' => 'a', 'second' => 'b', 'third' => null, 'fourth' => null
+        ];
+        $this->assertEqual($expected, $result);
+    }
+    
+    public function test_zero_width_param_names_edge_case() {
+        $result = preactIsoUrlPatternMatch("/test", "/:?");
+        $expected = ['params' => (object)['' => 'test'], '' => 'test'];
+        $this->assertEqual($expected, $result);
+    }
+    
+    // URL decoding error handling tests
+    
+    public function test_malformed_percent_encoding_simple_param() {
+        // Test malformed percent encoding in simple param - should not crash
+        $result = preactIsoUrlPatternMatch("/user/test%", "/user/:id");
+        // Should either work or return null, but not crash
+        $this->assertNotNull($result);
+    }
+    
+    public function test_malformed_percent_encoding_rest_param() {
+        // Test malformed percent encoding in rest param - should not crash
+        $result = preactIsoUrlPatternMatch("/files/test%/file", "/files/:path+");
+        // Should either work or return null, but not crash
+        $this->assertNotNull($result);
+    }
+    
+    public function test_invalid_unicode_sequence() {
+        // Test invalid unicode sequence - should not crash
+        $result = preactIsoUrlPatternMatch("/user/test%C3", "/user/:id");
+        // Should either work or return null, but not crash
+        $this->assertNotNull($result);
+    }
+}
+
+// Run tests if this file is executed directly
+if (php_sapi_name() === 'cli') {
+    $test = new TestPreactIsoUrlPatternMatch();
+    $test->run();
+}
+?>

--- a/polyglot-utils/php/test_preact_iso_url_pattern.php
+++ b/polyglot-utils/php/test_preact_iso_url_pattern.php
@@ -10,10 +10,10 @@ class TestPreactIsoUrlPatternMatch {
     private $tests = 0;
     private $passed = 0;
     private $failed = 0;
-    
+
     public function run() {
         echo "Running PHP tests for preact-iso-url-pattern...\n\n";
-        
+
         // Run all test methods
         $methods = get_class_methods($this);
         foreach ($methods as $method) {
@@ -21,16 +21,16 @@ class TestPreactIsoUrlPatternMatch {
                 $this->runTest($method);
             }
         }
-        
+
         echo "\n" . str_repeat("=", 60) . "\n";
         echo "Test Results: {$this->passed} passed, {$this->failed} failed, {$this->tests} total\n";
-        
+
         if ($this->failed > 0) {
             exit(1);
         }
         echo "All tests passed!\n";
     }
-    
+
     private function runTest($methodName) {
         $this->tests++;
         try {
@@ -43,159 +43,159 @@ class TestPreactIsoUrlPatternMatch {
             echo "\nFAILED: $methodName - " . $e->getMessage() . "\n";
         }
     }
-    
+
     private function assertEqual($expected, $actual, $message = '') {
         // Use JSON comparison for deep equality check (works for arrays and objects)
         $expectedJson = json_encode($expected);
         $actualJson = json_encode($actual);
-        
+
         if ($expectedJson !== $actualJson) {
             $expectedStr = json_encode($expected, JSON_PRETTY_PRINT);
             $actualStr = json_encode($actual, JSON_PRETTY_PRINT);
             throw new Exception("Expected:\n$expectedStr\nGot:\n$actualStr\n$message");
         }
     }
-    
+
     private function assertNull($actual, $message = '') {
         if ($actual !== null) {
             $actualStr = json_encode($actual, JSON_PRETTY_PRINT);
             throw new Exception("Expected null, got:\n$actualStr\n$message");
         }
     }
-    
+
     private function assertNotNull($actual, $message = '') {
         if ($actual === null) {
             throw new Exception("Expected non-null value, got null\n$message");
         }
     }
-    
+
     // Test methods start here
-    
+
     // Base route tests
     public function test_base_route_exact_match() {
         $result = preactIsoUrlPatternMatch("/", "/");
         $expected = ['params' => (object)[]];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_base_route_no_match() {
         $result = preactIsoUrlPatternMatch("/user/1", "/");
         $this->assertNull($result);
     }
-    
+
     // Param route tests
     public function test_param_route_match() {
         $result = preactIsoUrlPatternMatch("/user/2", "/user/:id");
         $expected = ['params' => (object)['id' => '2'], 'id' => '2'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_param_route_no_match() {
         $result = preactIsoUrlPatternMatch("/", "/user/:id");
         $this->assertNull($result);
     }
-    
+
     // Rest segment tests
     public function test_rest_segment_match() {
         $result = preactIsoUrlPatternMatch("/user/foo", "/user/*");
         $expected = ['params' => (object)[], 'rest' => '/foo'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_rest_segment_match_multiple_segments() {
         $result = preactIsoUrlPatternMatch("/user/foo/bar/baz", "/user/*");
         $expected = ['params' => (object)[], 'rest' => '/foo/bar/baz'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_rest_segment_no_match() {
         $result = preactIsoUrlPatternMatch("/user", "/user/*");
         $this->assertNull($result);
     }
-    
+
     public function test_rest_segment_no_match_different_case() {
         $result = preactIsoUrlPatternMatch("/", "/user/:id/*");
         $this->assertNull($result);
     }
-    
+
     // Param route with rest segment
     public function test_param_with_rest_single_segment() {
         $result = preactIsoUrlPatternMatch("/user/2/foo", "/user/:id/*");
         $expected = ['params' => (object)['id' => '2'], 'id' => '2', 'rest' => '/foo'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_param_with_rest_multiple_segments() {
         $result = preactIsoUrlPatternMatch("/user/2/foo/bar/bob", "/user/:id/*");
         $expected = ['params' => (object)['id' => '2'], 'id' => '2', 'rest' => '/foo/bar/bob'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_param_with_rest_no_match() {
         $result = preactIsoUrlPatternMatch("/", "/user/:id/*");
         $this->assertNull($result);
     }
-    
+
     // Optional param tests
     public function test_optional_param_empty() {
         $result = preactIsoUrlPatternMatch("/user", "/user/:id?");
         $expected = ['params' => (object)['id' => null], 'id' => null];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_optional_param_no_match_base() {
         $result = preactIsoUrlPatternMatch("/", "/user/:id?");
         $this->assertNull($result);
     }
-    
+
     // Optional rest param tests (/:x*)
     public function test_optional_rest_param_empty() {
         $result = preactIsoUrlPatternMatch("/user", "/user/:id*");
         $expected = ['params' => (object)['id' => null], 'id' => null];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_optional_rest_param_with_segments() {
         $result = preactIsoUrlPatternMatch("/user/foo/bar", "/user/:id*");
         $expected = ['params' => (object)['id' => 'foo/bar'], 'id' => 'foo/bar'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_optional_param_no_match_base_duplicate() {
         $result = preactIsoUrlPatternMatch("/", "/user/:id*");
         $this->assertNull($result);
     }
-    
+
     // Required rest param tests (/:x+)
     public function test_required_rest_param_single_segment() {
         $result = preactIsoUrlPatternMatch("/user/foo", "/user/:id+");
         $expected = ['params' => (object)['id' => 'foo'], 'id' => 'foo'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_required_rest_param_multiple_segments() {
         $result = preactIsoUrlPatternMatch("/user/foo/bar", "/user/:id+");
         $expected = ['params' => (object)['id' => 'foo/bar'], 'id' => 'foo/bar'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_required_rest_param_empty_should_fail() {
         $result = preactIsoUrlPatternMatch("/user", "/user/:id+");
         $this->assertNull($result);
     }
-    
+
     public function test_required_rest_param_root_mismatch() {
         $result = preactIsoUrlPatternMatch("/", "/user/:id+");
         $this->assertNull($result);
     }
-    
+
     // Leading/trailing slashes
     public function test_leading_trailing_slashes() {
         $result = preactIsoUrlPatternMatch("/about-late/_SEGMENT1_/_SEGMENT2_/", "/about-late/:seg1/:seg2/");
         $expected = ['params' => (object)['seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_'], 'seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_'];
         $this->assertEqual($expected, $result);
     }
-    
+
     // Additional tests that are not in test/node/router-match.test.js
     // URL encoding tests
     public function test_url_encoded_param() {
@@ -203,43 +203,43 @@ class TestPreactIsoUrlPatternMatch {
         $expected = ['params' => (object)['param' => 'bar baz'], 'param' => 'bar baz'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_url_encoded_email_in_param() {
         $result = preactIsoUrlPatternMatch("/users/test%40example.com/posts", "/users/:userId/posts");
         $expected = ['params' => (object)['userId' => 'test@example.com'], 'userId' => 'test@example.com'];
         $this->assertEqual($expected, $result);
     }
-    
+
     // Complex rest segment with encoding
     public function test_rest_segment_with_encoded_parts() {
         $result = preactIsoUrlPatternMatch("/api/path/with%20spaces/and%2Fslashes", "/api/:path+");
         $expected = ['params' => (object)['path' => 'path/with spaces/and/slashes'], 'path' => 'path/with spaces/and/slashes'];
         $this->assertEqual($expected, $result);
     }
-    
+
     // Edge cases
     public function test_empty_route() {
         $result = preactIsoUrlPatternMatch("/foo", "");
         $this->assertNull($result);
     }
-    
+
     public function test_empty_url_with_param() {
         $result = preactIsoUrlPatternMatch("", "/:param");
         $this->assertNull($result);
     }
-    
+
     public function test_mixed_required_and_optional_params() {
         $result = preactIsoUrlPatternMatch("/foo/bar", "/:required/:optional?");
         $expected = ['params' => (object)['required' => 'foo', 'optional' => 'bar'], 'required' => 'foo', 'optional' => 'bar'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_mixed_required_and_optional_params_missing_optional() {
         $result = preactIsoUrlPatternMatch("/foo", "/:required/:optional?");
         $expected = ['params' => (object)['required' => 'foo', 'optional' => null], 'required' => 'foo', 'optional' => null];
         $this->assertEqual($expected, $result);
     }
-    
+
     // Test with pre-existing matches
     public function test_pre_existing_matches_object() {
         $matches = ['params' => (object)['existing' => 'value']];
@@ -247,7 +247,7 @@ class TestPreactIsoUrlPatternMatch {
         $expected = ['params' => (object)['existing' => 'value', 'first' => 'foo', 'second' => 'bar'], 'first' => 'foo', 'second' => 'bar'];
         $this->assertEqual($expected, $result);
     }
-    
+
 
     // Complex nested paths
     public function test_complex_nested_path_with_multiple_params() {
@@ -258,12 +258,12 @@ class TestPreactIsoUrlPatternMatch {
         ];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_route_longer_than_url_required_param_missing() {
         $result = preactIsoUrlPatternMatch("/api", "/api/:version/:resource");
         $this->assertNull($result);
     }
-    
+
     public function test_route_longer_than_url_optional_param() {
         $result = preactIsoUrlPatternMatch("/api", "/api/:version?");
         $expected = ['params' => (object)['version' => null], 'version' => null];
@@ -275,7 +275,7 @@ class TestPreactIsoUrlPatternMatch {
         $expected = ['params' => (object)['id' => '123'], 'id' => '123'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_route_with_multiple_slashes() {
         $result = preactIsoUrlPatternMatch("/user/123", "//user//:id//");
         $expected = ['params' => (object)['id' => '123'], 'id' => '123'];
@@ -289,15 +289,15 @@ class TestPreactIsoUrlPatternMatch {
         $expected = ['params' => (object)['path' => 'folder/subfolder/file name.txt'], 'path' => 'folder/subfolder/file name.txt'];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_special_characters_encoded_in_url() {
         $result = preactIsoUrlPatternMatch("/search/query%3F%2B%23%26test", "/search/:query");
         $expected = ['params' => (object)['query' => 'query?+#&test'], 'query' => 'query?+#&test'];
         $this->assertEqual($expected, $result);
     }
-    
 
-    
+
+
     public function test_unicode_characters_encoded() {
         $result = preactIsoUrlPatternMatch("/user/Jos%C3%A9", "/user/:name");
         $expected = ['params' => (object)['name' => 'José'], 'name' => 'José'];
@@ -309,13 +309,13 @@ class TestPreactIsoUrlPatternMatch {
         $expected = ['params' => (object)[]];
         $this->assertEqual($expected, $result);
     }
-    
+
     public function test_route_with_only_wildcards() {
         $result = preactIsoUrlPatternMatch("/anything/goes/here", "*");
         $expected = ['params' => (object)[], 'rest' => '/anything/goes/here'];
         $this->assertEqual($expected, $result);
     }
-    
+
     // URL decoding error handling tests
     public function test_malformed_percent_encoding_simple_param() {
         // Test malformed percent encoding in simple param - should not crash
@@ -323,14 +323,14 @@ class TestPreactIsoUrlPatternMatch {
         // Should either work or return null, but not crash
         $this->assertNotNull($result);
     }
-    
+
     public function test_malformed_percent_encoding_rest_param() {
         // Test malformed percent encoding in rest param - should not crash
         $result = preactIsoUrlPatternMatch("/files/test%/file", "/files/:path+");
         // Should either work or return null, but not crash
         $this->assertNotNull($result);
     }
-    
+
     public function test_invalid_unicode_sequence() {
         // Test invalid unicode sequence - should not crash
         $result = preactIsoUrlPatternMatch("/user/test%C3", "/user/:id");

--- a/polyglot-utils/python/README.md
+++ b/polyglot-utils/python/README.md
@@ -38,7 +38,7 @@ def preact_iso_url_pattern_match(url, route, matches=None) -> dict | None
 ### Parameters
 
 - `url` (str): The URL path to match
-- `route` (str): The route pattern with parameters  
+- `route` (str): The route pattern with parameters
 - `matches` (dict, optional): Pre-existing matches dictionary to extend
 
 ### Return Value

--- a/polyglot-utils/python/README.md
+++ b/polyglot-utils/python/README.md
@@ -1,0 +1,64 @@
+# Python Implementation
+
+URL pattern matching utility for Python servers.
+
+## Setup
+
+Code tested on Python 3.12.x.
+
+No external dependencies required - uses only Python standard library.
+
+```sh
+python3 --version  # Ensure Python 3.6+ is available
+# No third party dependencies needed. Just run the tests or use the function directly
+```
+
+## Running Tests
+
+```sh
+python3 test_preact_iso_url_pattern.py
+```
+
+## Usage
+
+```python
+from preact_iso_url_pattern import preact_iso_url_pattern_match
+
+matches = preact_iso_url_pattern_match("/users/test%40example.com/posts", "/users/:userId/posts")
+if matches:
+    print(f"User ID: {matches['params']['userId']}")  # Output: test@example.com
+```
+
+## Function Signature
+
+```python
+def preact_iso_url_pattern_match(url, route, matches=None) -> dict | None
+```
+
+### Parameters
+
+- `url` (str): The URL path to match
+- `route` (str): The route pattern with parameters  
+- `matches` (dict, optional): Pre-existing matches dictionary to extend
+
+### Return Value
+
+Returns a dictionary on success, or `None` if no match:
+
+```python
+{
+    "params": {"userId": "123"},
+    "userId": "123",
+    "rest": "/additional/path"  # Optional
+}
+```
+
+## Route Patterns
+
+| Pattern | Description | Example Result |
+|---------|-------------|----------------|
+| `/users/:id` | Named parameter | `{"params": {"id": "123"}, "id": "123"}` |
+| `/users/:id?` | Optional parameter | `{"params": {"id": None}, "id": None}` |
+| `/files/:path+` | Required rest parameter | `{"params": {"path": "docs/readme.txt"}}` |
+| `/static/:path*` | Optional rest parameter | `{"params": {"path": "css/main.css"}}` |
+| `/static/*` | Anonymous wildcard | `{"params": {}, "rest": "/images/logo.png"}` |

--- a/polyglot-utils/python/preact_iso_url_pattern.py
+++ b/polyglot-utils/python/preact_iso_url_pattern.py
@@ -1,0 +1,73 @@
+# Run program: python3 preact-iso-url-pattern.py
+
+from urllib.parse import unquote
+
+# Safe URL decode function with error handling
+def safe_unquote(s):
+    if s is None or s == '':
+        return s
+    try:
+        return unquote(s)
+    except UnicodeDecodeError:
+        # If unquote fails due to malformed encoding, return original string
+        return s
+
+def preact_iso_url_pattern_match(url, route, matches=None):
+    # Initialize matches object if not provided
+    if matches is None:
+        matches = {'params': {}}
+    url = list(filter(None, url.split('/')))
+    route = list(filter(None, (route or '').split('/')))
+
+    for i in range(max(len(url), len(route))):
+        m, param, flag = '', '', ''
+        if i < len(route):
+            parts = route[i].split(':')
+            m = ':' if len(parts) > 1 else ''
+            param = parts[-1]
+            flag = ''
+            if param and param[-1] in '+*?':
+                flag = param[-1]
+                param = param[:-1]
+
+        val = url[i] if i < len(url) else None
+
+        # segment match:
+        if not m and param == val:
+            continue
+
+        # /foo/* match
+        if not m and val and flag == '*':
+            # Store remaining path segments in rest
+            matches['rest'] = '/' + '/'.join(map(safe_unquote, url[i:]))
+            break
+
+        # segment mismatch / missing required field:
+        if not m or (not val and flag != '?' and flag != '*'):
+            return None
+
+        rest = flag in ('+', '*')
+
+        # rest (+/*) match:
+        if rest:
+            val = '/'.join(map(safe_unquote, url[i:])) or None
+        # normal/optional field:
+        elif val:
+            val = safe_unquote(val)
+
+        # Store parameter values in matches
+        matches['params'][param] = val
+        if param not in matches:
+            matches[param] = val
+
+        if rest:
+            break
+
+    return matches
+
+# Example usage:
+# print(preact_iso_url_pattern_match("/foo/bar%20baz", "/foo/:param"))
+# print(preact_iso_url_pattern_match("/foo/bar/baz", "/foo/*"))
+# print(preact_iso_url_pattern_match("/foo", "/foo/:param?"))
+# print(preact_iso_url_pattern_match("/foo/bar", "/bar/:param"))
+# print(preact_iso_url_pattern_match('/users/test%40example.com/posts', '/users/:userId/posts'))

--- a/polyglot-utils/python/test_preact_iso_url_pattern.py
+++ b/polyglot-utils/python/test_preact_iso_url_pattern.py
@@ -6,132 +6,132 @@ from preact_iso_url_pattern import preact_iso_url_pattern_match
 
 
 class TestPreactIsoUrlPatternMatch(unittest.TestCase):
-    
+
     # Base route tests
     def test_base_route_exact_match(self):
         """Base route - exact match"""
         result = preact_iso_url_pattern_match("/", "/")
         expected = {'params': {}}
         self.assertEqual(result, expected)
-    
+
     def test_base_route_no_match(self):
         """Base route - no match"""
         result = preact_iso_url_pattern_match("/user/1", "/")
         self.assertIsNone(result)
-    
+
     # Param route tests
     def test_param_route_match(self):
         """Param route - match"""
         result = preact_iso_url_pattern_match("/user/2", "/user/:id")
         expected = {'params': {'id': '2'}, 'id': '2'}
         self.assertEqual(result, expected)
-    
+
     def test_param_route_no_match(self):
         """Param route - no match"""
         result = preact_iso_url_pattern_match("/", "/user/:id")
         self.assertIsNone(result)
-    
+
     # Rest segment tests
     def test_rest_segment_match(self):
         """Rest segment - match"""
         result = preact_iso_url_pattern_match("/user/foo", "/user/*")
         expected = {'params': {}, 'rest': '/foo'}
         self.assertEqual(result, expected)
-    
+
     def test_rest_segment_match_multiple_segments(self):
         """Rest segment - match multiple segments"""
         result = preact_iso_url_pattern_match("/user/foo/bar/baz", "/user/*")
         expected = {'params': {}, 'rest': '/foo/bar/baz'}
         self.assertEqual(result, expected)
-    
+
     def test_rest_segment_no_match(self):
         """Rest segment - no match"""
         result = preact_iso_url_pattern_match("/user", "/user/*")
         self.assertIsNone(result)
-    
+
     def test_rest_segment_no_match_different_case(self):
         """Rest segment - no match different case"""
         result = preact_iso_url_pattern_match("/", "/user/:id/*")
         self.assertIsNone(result)
-    
+
     # Param route with rest segment
     def test_param_with_rest_single_segment(self):
         """Param with rest - single segment"""
         result = preact_iso_url_pattern_match("/user/2/foo", "/user/:id/*")
         expected = {'params': {'id': '2'}, 'id': '2', 'rest': '/foo'}
         self.assertEqual(result, expected)
-    
+
     def test_param_with_rest_multiple_segments(self):
         """Param with rest - multiple segments"""
         result = preact_iso_url_pattern_match("/user/2/foo/bar/bob", "/user/:id/*")
         expected = {'params': {'id': '2'}, 'id': '2', 'rest': '/foo/bar/bob'}
         self.assertEqual(result, expected)
-    
+
     def test_param_with_rest_no_match(self):
         """Param with rest - no match"""
         result = preact_iso_url_pattern_match("/", "/user/:id/*")
         self.assertIsNone(result)
-    
+
     # Optional param tests
     def test_optional_param_empty(self):
         """Optional param - empty"""
         result = preact_iso_url_pattern_match("/user", "/user/:id?")
         expected = {'params': {'id': None}, 'id': None}
         self.assertEqual(result, expected)
-    
+
     def test_optional_param_no_match_base(self):
         """Optional param - no match base"""
         result = preact_iso_url_pattern_match("/", "/user/:id?")
         self.assertIsNone(result)
-    
+
     # Optional rest param tests (/:x*)
     def test_optional_rest_param_empty(self):
         """Optional rest param - empty"""
         result = preact_iso_url_pattern_match("/user", "/user/:id*")
         expected = {'params': {'id': None}, 'id': None}
         self.assertEqual(result, expected)
-    
+
     def test_optional_rest_param_with_segments(self):
         """Optional rest param - with segments"""
         result = preact_iso_url_pattern_match("/user/foo/bar", "/user/:id*")
         expected = {'params': {'id': 'foo/bar'}, 'id': 'foo/bar'}
         self.assertEqual(result, expected)
-    
+
     def test_optional_param_no_match_base_duplicate(self):
         """Optional param - no match base duplicate"""
         result = preact_iso_url_pattern_match("/", "/user/:id*")
         self.assertIsNone(result)
-    
+
     # Required rest param tests (/:x+)
     def test_required_rest_param_single_segment(self):
         """Required rest param - single segment"""
         result = preact_iso_url_pattern_match("/user/foo", "/user/:id+")
         expected = {'params': {'id': 'foo'}, 'id': 'foo'}
         self.assertEqual(result, expected)
-    
+
     def test_required_rest_param_multiple_segments(self):
         """Required rest param - multiple segments"""
         result = preact_iso_url_pattern_match("/user/foo/bar", "/user/:id+")
         expected = {'params': {'id': 'foo/bar'}, 'id': 'foo/bar'}
         self.assertEqual(result, expected)
-    
+
     def test_required_rest_param_empty_should_fail(self):
         """Required rest param - empty (should fail)"""
         result = preact_iso_url_pattern_match("/user", "/user/:id+")
         self.assertIsNone(result)
-    
+
     def test_required_rest_param_root_mismatch(self):
         """Required rest param - root mismatch"""
         result = preact_iso_url_pattern_match("/", "/user/:id+")
         self.assertIsNone(result)
-    
+
     # Leading/trailing slashes
     def test_leading_trailing_slashes(self):
         """Leading/trailing slashes"""
         result = preact_iso_url_pattern_match("/about-late/_SEGMENT1_/_SEGMENT2_/", "/about-late/:seg1/:seg2/")
         expected = {'params': {'seg1': '_SEGMENT1_', 'seg2': '_SEGMENT2_'}, 'seg1': '_SEGMENT1_', 'seg2': '_SEGMENT2_'}
         self.assertEqual(result, expected)
-    
+
     # Additional tests that are not in test/node/router-match.test.js
     # URL encoding tests
     def test_url_encoded_param(self):
@@ -139,43 +139,43 @@ class TestPreactIsoUrlPatternMatch(unittest.TestCase):
         result = preact_iso_url_pattern_match("/foo/bar%20baz", "/foo/:param")
         expected = {'params': {'param': 'bar baz'}, 'param': 'bar baz'}
         self.assertEqual(result, expected)
-    
+
     def test_url_encoded_email_in_param(self):
         """URL encoded email in param"""
         result = preact_iso_url_pattern_match("/users/test%40example.com/posts", "/users/:userId/posts")
         expected = {'params': {'userId': 'test@example.com'}, 'userId': 'test@example.com'}
         self.assertEqual(result, expected)
-    
+
     # Complex rest segment with encoding
     def test_rest_segment_with_encoded_parts(self):
         """Rest segment with encoded parts"""
         result = preact_iso_url_pattern_match("/api/path/with%20spaces/and%2Fslashes", "/api/:path+")
         expected = {'params': {'path': 'path/with spaces/and/slashes'}, 'path': 'path/with spaces/and/slashes'}
         self.assertEqual(result, expected)
-    
+
     # Edge cases
     def test_empty_route(self):
         """Empty route"""
         result = preact_iso_url_pattern_match("/foo", "")
         self.assertIsNone(result)
-    
+
     def test_empty_url_with_param(self):
         """Empty url with param"""
         result = preact_iso_url_pattern_match("", "/:param")
         self.assertIsNone(result)
-    
+
     def test_mixed_required_and_optional_params(self):
         """Mixed required and optional params"""
         result = preact_iso_url_pattern_match("/foo/bar", "/:required/:optional?")
         expected = {'params': {'required': 'foo', 'optional': 'bar'}, 'required': 'foo', 'optional': 'bar'}
         self.assertEqual(result, expected)
-    
+
     def test_mixed_required_and_optional_params_missing_optional(self):
         """Mixed required and optional params - missing optional"""
         result = preact_iso_url_pattern_match("/foo", "/:required/:optional?")
         expected = {'params': {'required': 'foo', 'optional': None}, 'required': 'foo', 'optional': None}
         self.assertEqual(result, expected)
-    
+
     # Test with pre-existing matches
     def test_pre_existing_matches_object(self):
         """Pre-existing matches object"""
@@ -193,24 +193,24 @@ class TestPreactIsoUrlPatternMatch(unittest.TestCase):
             'version': 'v1', 'userId': '123', 'postId': '456'
         }
         self.assertEqual(result, expected)
-    
+
     def test_route_longer_than_url_required_param_missing(self):
         """Route longer than URL - required param missing"""
         result = preact_iso_url_pattern_match("/api", "/api/:version/:resource")
         self.assertIsNone(result)
-    
+
     def test_route_longer_than_url_optional_param(self):
         """Route longer than URL - optional param"""
         result = preact_iso_url_pattern_match("/api", "/api/:version?")
         expected = {'params': {'version': None}, 'version': None}
         self.assertEqual(result, expected)
-    
+
     def test_multiple_slashes_in_url_should_be_normalized(self):
         """Multiple slashes in URL should be normalized"""
         result = preact_iso_url_pattern_match("//user//123//", "/user/:id")
         expected = {'params': {'id': '123'}, 'id': '123'}
         self.assertEqual(result, expected)
-    
+
     def test_route_with_multiple_slashes(self):
         """Route with multiple slashes"""
         result = preact_iso_url_pattern_match("/user/123", "//user//:id//")
@@ -222,13 +222,13 @@ class TestPreactIsoUrlPatternMatch(unittest.TestCase):
         result = preact_iso_url_pattern_match("/files/folder%2Fsubfolder/file%20name.txt", "/files/:path+")
         expected = {'params': {'path': 'folder/subfolder/file name.txt'}, 'path': 'folder/subfolder/file name.txt'}
         self.assertEqual(result, expected)
-    
+
     def test_special_characters_encoded_in_url(self):
         """Special characters encoded in URL"""
         result = preact_iso_url_pattern_match("/search/query%3F%2B%23%26test", "/search/:query")
         expected = {'params': {'query': 'query?+#&test'}, 'query': 'query?+#&test'}
         self.assertEqual(result, expected)
-    
+
     def test_unicode_characters_encoded(self):
         """Unicode characters encoded"""
         result = preact_iso_url_pattern_match("/user/Jos%C3%A9", "/user/:name")
@@ -240,30 +240,30 @@ class TestPreactIsoUrlPatternMatch(unittest.TestCase):
         result = preact_iso_url_pattern_match("/api//v1//users", "/api/v1/users")
         expected = {'params': {}}
         self.assertEqual(result, expected)
-    
+
     def test_route_with_only_wildcards(self):
         """Route with only wildcards"""
         result = preact_iso_url_pattern_match("/anything/goes/here", "*")
         expected = {'params': {}, 'rest': '/anything/goes/here'}
         self.assertEqual(result, expected)
-    
+
 
 class TestUrlDecodingErrorHandling(unittest.TestCase):
     """Tests specifically for URL decoding error scenarios"""
-    
+
     def test_malformed_percent_encoding_simple_param(self):
         """Test malformed percent encoding in simple param - should not crash"""
         # This should handle malformed encoding gracefully
         result = preact_iso_url_pattern_match("/user/test%", "/user/:id")
         # Should either work or return None, but not crash
         self.assertIsNotNone(result)
-    
+
     def test_malformed_percent_encoding_rest_param(self):
         """Test malformed percent encoding in rest param - should not crash"""
         result = preact_iso_url_pattern_match("/files/test%/file", "/files/:path+")
         # Should either work or return None, but not crash
         self.assertIsNotNone(result)
-    
+
     def test_invalid_unicode_sequence(self):
         """Test invalid unicode sequence - should not crash"""
         result = preact_iso_url_pattern_match("/user/test%C3", "/user/:id")

--- a/polyglot-utils/python/test_preact_iso_url_pattern.py
+++ b/polyglot-utils/python/test_preact_iso_url_pattern.py
@@ -35,8 +35,19 @@ class TestPreactIsoUrlPatternMatch(unittest.TestCase):
         expected = {'params': {}, 'rest': '/foo'}
         self.assertEqual(result, expected)
     
+    def test_rest_segment_match_multiple_segments(self):
+        """Rest segment - match multiple segments"""
+        result = preact_iso_url_pattern_match("/user/foo/bar/baz", "/user/*")
+        expected = {'params': {}, 'rest': '/foo/bar/baz'}
+        self.assertEqual(result, expected)
+    
     def test_rest_segment_no_match(self):
         """Rest segment - no match"""
+        result = preact_iso_url_pattern_match("/user", "/user/*")
+        self.assertIsNone(result)
+    
+    def test_rest_segment_no_match_different_case(self):
+        """Rest segment - no match different case"""
         result = preact_iso_url_pattern_match("/", "/user/:id/*")
         self.assertIsNone(result)
     

--- a/polyglot-utils/python/test_preact_iso_url_pattern.py
+++ b/polyglot-utils/python/test_preact_iso_url_pattern.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Test suite for preact_iso_url_pattern.py - ported from Go tests"""
+
+import unittest
+from preact_iso_url_pattern import preact_iso_url_pattern_match
+
+
+class TestPreactIsoUrlPatternMatch(unittest.TestCase):
+    
+    def test_base_route_exact_match(self):
+        """Base route - exact match"""
+        result = preact_iso_url_pattern_match("/", "/")
+        expected = {'params': {}}
+        self.assertEqual(result, expected)
+    
+    def test_base_route_no_match(self):
+        """Base route - no match"""
+        result = preact_iso_url_pattern_match("/user/1", "/")
+        self.assertIsNone(result)
+    
+    def test_param_route_match(self):
+        """Param route - match"""
+        result = preact_iso_url_pattern_match("/user/2", "/user/:id")
+        expected = {'params': {'id': '2'}, 'id': '2'}
+        self.assertEqual(result, expected)
+    
+    def test_param_route_no_match(self):
+        """Param route - no match"""
+        result = preact_iso_url_pattern_match("/", "/user/:id")
+        self.assertIsNone(result)
+    
+    def test_rest_segment_match(self):
+        """Rest segment - match"""
+        result = preact_iso_url_pattern_match("/user/foo", "/user/*")
+        expected = {'params': {}, 'rest': '/foo'}
+        self.assertEqual(result, expected)
+    
+    def test_rest_segment_no_match(self):
+        """Rest segment - no match"""
+        result = preact_iso_url_pattern_match("/", "/user/:id/*")
+        self.assertIsNone(result)
+    
+    def test_param_with_rest_single_segment(self):
+        """Param with rest - single segment"""
+        result = preact_iso_url_pattern_match("/user/2/foo", "/user/:id/*")
+        expected = {'params': {'id': '2'}, 'id': '2', 'rest': '/foo'}
+        self.assertEqual(result, expected)
+    
+    def test_param_with_rest_multiple_segments(self):
+        """Param with rest - multiple segments"""
+        result = preact_iso_url_pattern_match("/user/2/foo/bar/bob", "/user/:id/*")
+        expected = {'params': {'id': '2'}, 'id': '2', 'rest': '/foo/bar/bob'}
+        self.assertEqual(result, expected)
+    
+    def test_optional_param_empty(self):
+        """Optional param - empty"""
+        result = preact_iso_url_pattern_match("/user", "/user/:id?")
+        expected = {'params': {'id': None}, 'id': None}
+        self.assertEqual(result, expected)
+    
+    def test_optional_param_no_match_base(self):
+        """Optional param - no match base"""
+        result = preact_iso_url_pattern_match("/", "/user/:id?")
+        self.assertIsNone(result)
+    
+    def test_optional_rest_param_empty(self):
+        """Optional rest param - empty"""
+        result = preact_iso_url_pattern_match("/user", "/user/:id*")
+        expected = {'params': {'id': None}, 'id': None}
+        self.assertEqual(result, expected)
+    
+    def test_optional_rest_param_with_segments(self):
+        """Optional rest param - with segments"""
+        result = preact_iso_url_pattern_match("/user/foo/bar", "/user/:id*")
+        expected = {'params': {'id': 'foo/bar'}, 'id': 'foo/bar'}
+        self.assertEqual(result, expected)
+    
+    def test_required_rest_param_single_segment(self):
+        """Required rest param - single segment"""
+        result = preact_iso_url_pattern_match("/user/foo", "/user/:id+")
+        expected = {'params': {'id': 'foo'}, 'id': 'foo'}
+        self.assertEqual(result, expected)
+    
+    def test_required_rest_param_multiple_segments(self):
+        """Required rest param - multiple segments"""
+        result = preact_iso_url_pattern_match("/user/foo/bar", "/user/:id+")
+        expected = {'params': {'id': 'foo/bar'}, 'id': 'foo/bar'}
+        self.assertEqual(result, expected)
+    
+    def test_required_rest_param_empty_should_fail(self):
+        """Required rest param - empty (should fail)"""
+        result = preact_iso_url_pattern_match("/user", "/user/:id+")
+        self.assertIsNone(result)
+    
+    def test_required_rest_param_root_mismatch(self):
+        """Required rest param - root mismatch"""
+        result = preact_iso_url_pattern_match("/", "/user/:id+")
+        self.assertIsNone(result)
+    
+    def test_leading_trailing_slashes(self):
+        """Leading/trailing slashes"""
+        result = preact_iso_url_pattern_match("/about-late/_SEGMENT1_/_SEGMENT2_/", "/about-late/:seg1/:seg2/")
+        expected = {'params': {'seg1': '_SEGMENT1_', 'seg2': '_SEGMENT2_'}, 'seg1': '_SEGMENT1_', 'seg2': '_SEGMENT2_'}
+        self.assertEqual(result, expected)
+    
+    def test_url_encoded_param(self):
+        """URL encoded param"""
+        result = preact_iso_url_pattern_match("/foo/bar%20baz", "/foo/:param")
+        expected = {'params': {'param': 'bar baz'}, 'param': 'bar baz'}
+        self.assertEqual(result, expected)
+    
+    def test_url_encoded_email_in_param(self):
+        """URL encoded email in param"""
+        result = preact_iso_url_pattern_match("/users/test%40example.com/posts", "/users/:userId/posts")
+        expected = {'params': {'userId': 'test@example.com'}, 'userId': 'test@example.com'}
+        self.assertEqual(result, expected)
+    
+    def test_rest_segment_with_encoded_parts(self):
+        """Rest segment with encoded parts"""
+        result = preact_iso_url_pattern_match("/api/path/with%20spaces/and%2Fslashes", "/api/:path+")
+        expected = {'params': {'path': 'path/with spaces/and/slashes'}, 'path': 'path/with spaces/and/slashes'}
+        self.assertEqual(result, expected)
+    
+    def test_empty_route(self):
+        """Empty route"""
+        result = preact_iso_url_pattern_match("/foo", "")
+        self.assertIsNone(result)
+    
+    def test_empty_url_with_param(self):
+        """Empty url with param"""
+        result = preact_iso_url_pattern_match("", "/:param")
+        self.assertIsNone(result)
+    
+    def test_multiple_optional_params(self):
+        """Multiple optional params"""
+        result = preact_iso_url_pattern_match("/foo", "/:a?/:b?/:c?")
+        expected = {'params': {'a': 'foo', 'b': None, 'c': None}, 'a': 'foo', 'b': None, 'c': None}
+        self.assertEqual(result, expected)
+    
+    def test_mixed_required_and_optional_params(self):
+        """Mixed required and optional params"""
+        result = preact_iso_url_pattern_match("/foo/bar", "/:required/:optional?")
+        expected = {'params': {'required': 'foo', 'optional': 'bar'}, 'required': 'foo', 'optional': 'bar'}
+        self.assertEqual(result, expected)
+    
+    def test_mixed_required_and_optional_params_missing_optional(self):
+        """Mixed required and optional params - missing optional"""
+        result = preact_iso_url_pattern_match("/foo", "/:required/:optional?")
+        expected = {'params': {'required': 'foo', 'optional': None}, 'required': 'foo', 'optional': None}
+        self.assertEqual(result, expected)
+    
+    def test_pre_existing_matches_object(self):
+        """Pre-existing matches object"""
+        matches = {'params': {'existing': 'value'}}
+        result = preact_iso_url_pattern_match("/foo/bar", "/:first/:second", matches)
+        expected = {'params': {'existing': 'value', 'first': 'foo', 'second': 'bar'}, 'first': 'foo', 'second': 'bar'}
+        self.assertEqual(result, expected)
+    
+    def test_anonymous_wildcard_rest(self):
+        """Anonymous wildcard rest"""
+        result = preact_iso_url_pattern_match("/static/css/main.css", "/static/*")
+        expected = {'params': {}, 'rest': '/css/main.css'}
+        self.assertEqual(result, expected)
+    
+    def test_complex_nested_path_with_multiple_params(self):
+        """Complex nested path with multiple params"""
+        result = preact_iso_url_pattern_match("/api/v1/users/123/posts/456/comments", "/api/:version/users/:userId/posts/:postId/comments")
+        expected = {
+            'params': {'version': 'v1', 'userId': '123', 'postId': '456'},
+            'version': 'v1', 'userId': '123', 'postId': '456'
+        }
+        self.assertEqual(result, expected)
+    
+    def test_route_longer_than_url_required_param_missing(self):
+        """Route longer than URL - required param missing"""
+        result = preact_iso_url_pattern_match("/api", "/api/:version/:resource")
+        self.assertIsNone(result)
+    
+    def test_route_longer_than_url_optional_param(self):
+        """Route longer than URL - optional param"""
+        result = preact_iso_url_pattern_match("/api", "/api/:version?")
+        expected = {'params': {'version': None}, 'version': None}
+        self.assertEqual(result, expected)
+    
+    def test_empty_string_should_be_handled_as_undefined_for_optional_rest(self):
+        """Empty string should be handled as undefined for optional rest"""
+        result = preact_iso_url_pattern_match("/user", "/user/:id*")
+        expected = {'params': {'id': None}, 'id': None}
+        self.assertEqual(result, expected)
+    
+    def test_multiple_slashes_in_url_should_be_normalized(self):
+        """Multiple slashes in URL should be normalized"""
+        result = preact_iso_url_pattern_match("//user//123//", "/user/:id")
+        expected = {'params': {'id': '123'}, 'id': '123'}
+        self.assertEqual(result, expected)
+    
+    def test_route_with_multiple_slashes(self):
+        """Route with multiple slashes"""
+        result = preact_iso_url_pattern_match("/user/123", "//user//:id//")
+        expected = {'params': {'id': '123'}, 'id': '123'}
+        self.assertEqual(result, expected)
+    
+    def test_special_characters_in_param_names(self):
+        """Special characters in param names"""
+        result = preact_iso_url_pattern_match("/user/123", "/user/:user_id")
+        expected = {'params': {'user_id': '123'}, 'user_id': '123'}
+        self.assertEqual(result, expected)
+    
+    def test_param_with_numbers(self):
+        """Param with numbers"""
+        result = preact_iso_url_pattern_match("/api/v1", "/api/:version1")
+        expected = {'params': {'version1': 'v1'}, 'version1': 'v1'}
+        self.assertEqual(result, expected)
+    
+    def test_rest_param_with_single_character(self):
+        """Rest param with single character"""
+        result = preact_iso_url_pattern_match("/a/b", "/:x+")
+        expected = {'params': {'x': 'a/b'}, 'x': 'a/b'}
+        self.assertEqual(result, expected)
+    
+    def test_complex_url_encoding_in_rest_params(self):
+        """Complex URL encoding in rest params"""
+        result = preact_iso_url_pattern_match("/files/folder%2Fsubfolder/file%20name.txt", "/files/:path+")
+        expected = {'params': {'path': 'folder/subfolder/file name.txt'}, 'path': 'folder/subfolder/file name.txt'}
+        self.assertEqual(result, expected)
+    
+    def test_question_mark_in_url_not_query_param(self):
+        """Question mark in URL (not query param)"""
+        result = preact_iso_url_pattern_match("/search/what%3F", "/search/:query")
+        expected = {'params': {'query': 'what?'}, 'query': 'what?'}
+        self.assertEqual(result, expected)
+    
+    def test_plus_sign_in_url(self):
+        """Plus sign in URL"""
+        result = preact_iso_url_pattern_match("/math/1%2B1", "/math/:expression")
+        expected = {'params': {'expression': '1+1'}, 'expression': '1+1'}
+        self.assertEqual(result, expected)
+    
+    def test_hash_in_url_encoded(self):
+        """Hash in URL (encoded)"""
+        result = preact_iso_url_pattern_match("/tag/%23javascript", "/tag/:name")
+        expected = {'params': {'name': '#javascript'}, 'name': '#javascript'}
+        self.assertEqual(result, expected)
+    
+    def test_ampersand_in_url(self):
+        """Ampersand in URL"""
+        result = preact_iso_url_pattern_match("/search/cats%26dogs", "/search/:query")
+        expected = {'params': {'query': 'cats&dogs'}, 'query': 'cats&dogs'}
+        self.assertEqual(result, expected)
+    
+    def test_unicode_characters(self):
+        """Unicode characters"""
+        result = preact_iso_url_pattern_match("/user/José", "/user/:name")
+        expected = {'params': {'name': 'José'}, 'name': 'José'}
+        self.assertEqual(result, expected)
+    
+    def test_unicode_characters_encoded(self):
+        """Unicode characters encoded"""
+        result = preact_iso_url_pattern_match("/user/Jos%C3%A9", "/user/:name")
+        expected = {'params': {'name': 'José'}, 'name': 'José'}
+        self.assertEqual(result, expected)
+    
+    def test_very_long_param(self):
+        """Very long param"""
+        long_content = 'a' * 1000
+        result = preact_iso_url_pattern_match(f"/data/{long_content}", "/data/:content")
+        expected = {'params': {'content': long_content}, 'content': long_content}
+        self.assertEqual(result, expected)
+    
+    def test_empty_segments_in_middle_of_url(self):
+        """Empty segments in middle of URL"""
+        result = preact_iso_url_pattern_match("/api//v1//users", "/api/v1/users")
+        expected = {'params': {}}
+        self.assertEqual(result, expected)
+    
+    def test_route_with_only_wildcards(self):
+        """Route with only wildcards"""
+        result = preact_iso_url_pattern_match("/anything/goes/here", "*")
+        expected = {'params': {}, 'rest': '/anything/goes/here'}
+        self.assertEqual(result, expected)
+    
+    def test_multiple_consecutive_optional_params(self):
+        """Multiple consecutive optional params"""
+        result = preact_iso_url_pattern_match("/a/b", "/:first?/:second?/:third?/:fourth?")
+        expected = {
+            'params': {'first': 'a', 'second': 'b', 'third': None, 'fourth': None},
+            'first': 'a', 'second': 'b', 'third': None, 'fourth': None
+        }
+        self.assertEqual(result, expected)
+    
+    def test_zero_width_param_names_edge_case(self):
+        """Zero-width param names (edge case)"""
+        result = preact_iso_url_pattern_match("/test", "/:?")
+        expected = {'params': {'': 'test'}, '': 'test'}
+        self.assertEqual(result, expected)
+
+
+class TestUrlDecodingErrorHandling(unittest.TestCase):
+    """Tests specifically for URL decoding error scenarios"""
+    
+    def test_malformed_percent_encoding_simple_param(self):
+        """Test malformed percent encoding in simple param - should not crash"""
+        # This should handle malformed encoding gracefully
+        result = preact_iso_url_pattern_match("/user/test%", "/user/:id")
+        # Should either work or return None, but not crash
+        self.assertIsNotNone(result)
+    
+    def test_malformed_percent_encoding_rest_param(self):
+        """Test malformed percent encoding in rest param - should not crash"""
+        result = preact_iso_url_pattern_match("/files/test%/file", "/files/:path+")
+        # Should either work or return None, but not crash
+        self.assertIsNotNone(result)
+    
+    def test_invalid_unicode_sequence(self):
+        """Test invalid unicode sequence - should not crash"""
+        result = preact_iso_url_pattern_match("/user/test%C3", "/user/:id")
+        # Should either work or return None, but not crash
+        self.assertIsNotNone(result)
+
+
+if __name__ == '__main__':
+    # Run tests with verbose output
+    unittest.main(verbosity=2)

--- a/polyglot-utils/ruby/README.md
+++ b/polyglot-utils/ruby/README.md
@@ -1,0 +1,63 @@
+# Ruby Implementation
+
+URL pattern matching utility for Ruby servers.
+
+## Setup
+
+Code tested on ruby 3.2.x.
+
+```sh
+ruby --version  # Ensure Ruby 2.0+ is available
+# No third party dependencies needed. Just run the tests or use the function directly
+```
+
+## Running Tests
+
+```sh
+ruby test_preact_iso_url_pattern.rb
+```
+
+## Usage
+
+```ruby
+require_relative 'preact-iso-url-pattern'
+
+matches = preact_iso_url_pattern_match("/users/test%40example.com/posts", "/users/:userId/posts")
+if matches
+  puts "User ID: #{matches['params']['userId']}"  # Output: test@example.com
+end
+```
+
+## Function Signature
+
+```ruby
+def preact_iso_url_pattern_match(url, route, matches = nil) -> Hash | nil
+```
+
+### Parameters
+
+- `url` (String): The URL path to match
+- `route` (String): The route pattern with parameters
+- `matches` (Hash, optional): Pre-existing matches hash to extend
+
+### Return Value
+
+Returns a Hash on success, or `nil` if no match:
+
+```ruby
+{
+  'params' => { 'userId' => '123' },
+  'userId' => '123',
+  'rest' => '/additional/path'  # Optional
+}
+```
+
+## Route Patterns
+
+| Pattern | Description | Example Result |
+|---------|-------------|----------------|
+| `/users/:id` | Named parameter | `{'params' => {'id' => '123'}, 'id' => '123'}` |
+| `/users/:id?` | Optional parameter | `{'params' => {'id' => nil}, 'id' => nil}` |
+| `/files/:path+` | Required rest parameter | `{'params' => {'path' => 'docs/readme.txt'}}` |
+| `/static/:path*` | Optional rest parameter | `{'params' => {'path' => 'css/main.css'}}` |
+| `/static/*` | Anonymous wildcard | `{'params' => {}, 'rest' => '/images/logo.png'}` |

--- a/polyglot-utils/ruby/preact-iso-url-pattern.rb
+++ b/polyglot-utils/ruby/preact-iso-url-pattern.rb
@@ -1,0 +1,64 @@
+# Run program: ruby preact-iso-url-pattern.rb
+require 'cgi'
+
+# Safe URL decode function with error handling  
+def safe_cgi_unescape(str)
+  return str if str.nil? || str.empty?
+  
+  begin
+    CGI.unescape(str)
+  rescue ArgumentError
+    # If CGI.unescape fails due to malformed encoding, return original string
+    str
+  end
+end
+
+def preact_iso_url_pattern_match(url, route, matches = nil)
+  matches ||= { 'params' => {} }
+  url = url.split('/').reject(&:empty?)
+  route = (route || '').split('/').reject(&:empty?)
+
+  (0...[url.length, route.length].max).each do |i|
+    m, param, flag = route[i]&.match(/^(:?)(.*?)([+*?]?)$/)&.captures || ['', '', '']
+    val = url[i]
+
+    # segment match:
+    next if m.empty? && param == val
+
+    # /foo/* match
+    if m.empty? && val && flag == '*'
+      decoded_parts = url[i..].map { |part| safe_cgi_unescape(part) }
+      matches['rest'] = '/' + decoded_parts.join('/')
+      break
+    end
+
+    # segment mismatch / missing required field:
+    return nil if m.empty? || (!val && flag != '?' && flag != '*')
+
+    rest = flag == '+' || flag == '*'
+
+    # rest (+/*) match:
+    if rest
+      decoded_parts = url[i..].map { |part| safe_cgi_unescape(part) }
+      joined = decoded_parts.join('/')
+      val = joined.empty? ? nil : joined
+    # normal/optional field:
+    elsif val
+      val = safe_cgi_unescape(val)
+    end
+
+    matches['params'][param] = val
+    matches[param] = val unless matches.key?(param)
+
+    break if rest
+  end
+
+  matches
+end
+
+# Example usage:
+# puts preact_iso_url_pattern_match("/foo/bar%20baz", "/foo/:param")
+# puts preact_iso_url_pattern_match("/foo/bar/baz", "/foo/*")
+# puts preact_iso_url_pattern_match("/foo", "/foo/:param?")
+# puts preact_iso_url_pattern_match("/foo/bar", "/bar/:param")
+# puts preact_iso_url_pattern_match('/users/test%40example.com/posts', '/users/:userId/posts')

--- a/polyglot-utils/ruby/preact-iso-url-pattern.rb
+++ b/polyglot-utils/ruby/preact-iso-url-pattern.rb
@@ -1,10 +1,10 @@
 # Run program: ruby preact-iso-url-pattern.rb
 require 'cgi'
 
-# Safe URL decode function with error handling  
+# Safe URL decode function with error handling
 def safe_cgi_unescape(str)
   return str if str.nil? || str.empty?
-  
+
   begin
     CGI.unescape(str)
   rescue ArgumentError

--- a/polyglot-utils/ruby/test_preact_iso_url_pattern.rb
+++ b/polyglot-utils/ruby/test_preact_iso_url_pattern.rb
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 require_relative 'preact-iso-url-pattern'
 
 class TestPreactIsoUrlPatternMatch < Minitest::Test
-  
+
   # Base route tests
   def test_base_route_exact_match
     # Base route - exact match
@@ -13,13 +13,13 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => {} }
     assert_equal expected, result
   end
-  
+
   def test_base_route_no_match
     # Base route - no match
     result = preact_iso_url_pattern_match("/user/1", "/")
     assert_nil result
   end
-  
+
   # Param route tests
   def test_param_route_match
     # Param route - match
@@ -27,13 +27,13 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'id' => '2' }, 'id' => '2' }
     assert_equal expected, result
   end
-  
+
   def test_param_route_no_match
     # Param route - no match
     result = preact_iso_url_pattern_match("/", "/user/:id")
     assert_nil result
   end
-  
+
   # Rest segment tests
   def test_rest_segment_match
     # Rest segment - match
@@ -41,26 +41,26 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => {}, 'rest' => '/foo' }
     assert_equal expected, result
   end
-  
+
   def test_rest_segment_match_multiple_segments
     # Rest segment - match multiple segments
     result = preact_iso_url_pattern_match("/user/foo/bar/baz", "/user/*")
     expected = { 'params' => {}, 'rest' => '/foo/bar/baz' }
     assert_equal expected, result
   end
-  
+
   def test_rest_segment_no_match
     # Rest segment - no match
     result = preact_iso_url_pattern_match("/user", "/user/*")
     assert_nil result
   end
-  
+
   def test_rest_segment_no_match_different_case
     # Rest segment - no match different case
     result = preact_iso_url_pattern_match("/", "/user/:id/*")
     assert_nil result
   end
-  
+
   # Param route with rest segment
   def test_param_with_rest_single_segment
     # Param with rest - single segment
@@ -68,20 +68,20 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'id' => '2' }, 'id' => '2', 'rest' => '/foo' }
     assert_equal expected, result
   end
-  
+
   def test_param_with_rest_multiple_segments
     # Param with rest - multiple segments
     result = preact_iso_url_pattern_match("/user/2/foo/bar/bob", "/user/:id/*")
     expected = { 'params' => { 'id' => '2' }, 'id' => '2', 'rest' => '/foo/bar/bob' }
     assert_equal expected, result
   end
-  
+
   def test_param_with_rest_no_match
     # Param with rest - no match
     result = preact_iso_url_pattern_match("/", "/user/:id/*")
     assert_nil result
   end
-  
+
   # Optional param tests
   def test_optional_param_empty
     # Optional param - empty
@@ -89,13 +89,13 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'id' => nil }, 'id' => nil }
     assert_equal expected, result
   end
-  
+
   def test_optional_param_no_match_base
     # Optional param - no match base
     result = preact_iso_url_pattern_match("/", "/user/:id?")
     assert_nil result
   end
-  
+
   # Optional rest param tests (/:x*)
   def test_optional_rest_param_empty
     # Optional rest param - empty
@@ -103,20 +103,20 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'id' => nil }, 'id' => nil }
     assert_equal expected, result
   end
-  
+
   def test_optional_rest_param_with_segments
     # Optional rest param - with segments
     result = preact_iso_url_pattern_match("/user/foo/bar", "/user/:id*")
     expected = { 'params' => { 'id' => 'foo/bar' }, 'id' => 'foo/bar' }
     assert_equal expected, result
   end
-  
+
   def test_optional_param_no_match_base_duplicate
     # Optional param - no match base duplicate
     result = preact_iso_url_pattern_match("/", "/user/:id*")
     assert_nil result
   end
-  
+
   # Required rest param tests (/:x+)
   def test_required_rest_param_single_segment
     # Required rest param - single segment
@@ -124,26 +124,26 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'id' => 'foo' }, 'id' => 'foo' }
     assert_equal expected, result
   end
-  
+
   def test_required_rest_param_multiple_segments
     # Required rest param - multiple segments
     result = preact_iso_url_pattern_match("/user/foo/bar", "/user/:id+")
     expected = { 'params' => { 'id' => 'foo/bar' }, 'id' => 'foo/bar' }
     assert_equal expected, result
   end
-  
+
   def test_required_rest_param_empty_should_fail
     # Required rest param - empty (should fail)
     result = preact_iso_url_pattern_match("/user", "/user/:id+")
     assert_nil result
   end
-  
+
   def test_required_rest_param_root_mismatch
     # Required rest param - root mismatch
     result = preact_iso_url_pattern_match("/", "/user/:id+")
     assert_nil result
   end
-  
+
   # Leading/trailing slashes
   def test_leading_trailing_slashes
     # Leading/trailing slashes
@@ -151,7 +151,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_' }, 'seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_' }
     assert_equal expected, result
   end
-  
+
   # Additional tests that are not in test/node/router-match.test.js
   # URL encoding tests
   def test_url_encoded_param
@@ -160,14 +160,14 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'param' => 'bar baz' }, 'param' => 'bar baz' }
     assert_equal expected, result
   end
-  
+
   def test_url_encoded_email_in_param
     # URL encoded email in param
     result = preact_iso_url_pattern_match("/users/test%40example.com/posts", "/users/:userId/posts")
     expected = { 'params' => { 'userId' => 'test@example.com' }, 'userId' => 'test@example.com' }
     assert_equal expected, result
   end
-  
+
   # Complex rest segment with encoding
   def test_rest_segment_with_encoded_parts
     # Rest segment with encoded parts
@@ -175,34 +175,34 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'path' => 'path/with spaces/and/slashes' }, 'path' => 'path/with spaces/and/slashes' }
     assert_equal expected, result
   end
-  
+
   # Edge cases
   def test_empty_route
     # Empty route
     result = preact_iso_url_pattern_match("/foo", "")
     assert_nil result
   end
-  
+
   def test_empty_url_with_param
     # Empty url with param
     result = preact_iso_url_pattern_match("", "/:param")
     assert_nil result
   end
-  
+
   def test_mixed_required_and_optional_params
     # Mixed required and optional params
     result = preact_iso_url_pattern_match("/foo/bar", "/:required/:optional?")
     expected = { 'params' => { 'required' => 'foo', 'optional' => 'bar' }, 'required' => 'foo', 'optional' => 'bar' }
     assert_equal expected, result
   end
-  
+
   def test_mixed_required_and_optional_params_missing_optional
     # Mixed required and optional params - missing optional
     result = preact_iso_url_pattern_match("/foo", "/:required/:optional?")
     expected = { 'params' => { 'required' => 'foo', 'optional' => nil }, 'required' => 'foo', 'optional' => nil }
     assert_equal expected, result
   end
-  
+
   # Test with pre-existing matches
   def test_pre_existing_matches_object
     # Pre-existing matches object
@@ -222,20 +222,20 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     }
     assert_equal expected, result
   end
-  
+
   def test_route_longer_than_url_required_param_missing
     # Route longer than URL - required param missing
     result = preact_iso_url_pattern_match("/api", "/api/:version/:resource")
     assert_nil result
   end
-  
+
   def test_route_longer_than_url_optional_param
     # Route longer than URL - optional param
     result = preact_iso_url_pattern_match("/api", "/api/:version?")
     expected = { 'params' => { 'version' => nil }, 'version' => nil }
     assert_equal expected, result
   end
-  
+
 
   def test_multiple_slashes_in_url_should_be_normalized
     # Multiple slashes in URL should be normalized
@@ -243,7 +243,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'id' => '123' }, 'id' => '123' }
     assert_equal expected, result
   end
-  
+
   def test_route_with_multiple_slashes
     # Route with multiple slashes
     result = preact_iso_url_pattern_match("/user/123", "//user//:id//")
@@ -257,21 +257,21 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'x' => 'a/b' }, 'x' => 'a/b' }
     assert_equal expected, result
   end
-  
+
   def test_complex_url_encoding_in_rest_params
     # Complex URL encoding in rest params
     result = preact_iso_url_pattern_match("/files/folder%2Fsubfolder/file%20name.txt", "/files/:path+")
     expected = { 'params' => { 'path' => 'folder/subfolder/file name.txt' }, 'path' => 'folder/subfolder/file name.txt' }
     assert_equal expected, result
   end
-  
+
   def test_special_characters_encoded_in_url
     # Special characters encoded in URL
     result = preact_iso_url_pattern_match("/search/query%3F%2B%23%26test", "/search/:query")
     expected = { 'params' => { 'query' => 'query?+#&test' }, 'query' => 'query?+#&test' }
     assert_equal expected, result
   end
-  
+
   def test_unicode_characters_encoded
     # Unicode characters encoded
     result = preact_iso_url_pattern_match("/user/Jos%C3%A9", "/user/:name")
@@ -285,19 +285,19 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => {} }
     assert_equal expected, result
   end
-  
+
   def test_route_with_only_wildcards
     # Route with only wildcards
     result = preact_iso_url_pattern_match("/anything/goes/here", "*")
     expected = { 'params' => {}, 'rest' => '/anything/goes/here' }
     assert_equal expected, result
   end
-  
+
 end
 
 class TestUrlDecodingErrorHandling < Minitest::Test
   # Tests specifically for URL decoding error scenarios
-  
+
   def test_malformed_percent_encoding_simple_param
     # Test malformed percent encoding in simple param - should not crash
     # This should handle malformed encoding gracefully
@@ -305,14 +305,14 @@ class TestUrlDecodingErrorHandling < Minitest::Test
     # Should either work or return nil, but not crash
     refute_nil result
   end
-  
+
   def test_malformed_percent_encoding_rest_param
     # Test malformed percent encoding in rest param - should not crash
     result = preact_iso_url_pattern_match("/files/test%/file", "/files/:path+")
     # Should either work or return nil, but not crash
     refute_nil result
   end
-  
+
   def test_invalid_unicode_sequence
     # Test invalid unicode sequence - should not crash
     result = preact_iso_url_pattern_match("/user/test%C3", "/user/:id")

--- a/polyglot-utils/ruby/test_preact_iso_url_pattern.rb
+++ b/polyglot-utils/ruby/test_preact_iso_url_pattern.rb
@@ -1,0 +1,374 @@
+#!/usr/bin/env ruby
+# Test suite for preact-iso-url-pattern.rb - ported from Go tests
+
+require 'minitest/autorun'
+require_relative 'preact-iso-url-pattern'
+
+class TestPreactIsoUrlPatternMatch < Minitest::Test
+  
+  def test_base_route_exact_match
+    # Base route - exact match
+    result = preact_iso_url_pattern_match("/", "/")
+    expected = { 'params' => {} }
+    assert_equal expected, result
+  end
+  
+  def test_base_route_no_match
+    # Base route - no match
+    result = preact_iso_url_pattern_match("/user/1", "/")
+    assert_nil result
+  end
+  
+  def test_param_route_match
+    # Param route - match
+    result = preact_iso_url_pattern_match("/user/2", "/user/:id")
+    expected = { 'params' => { 'id' => '2' }, 'id' => '2' }
+    assert_equal expected, result
+  end
+  
+  def test_param_route_no_match
+    # Param route - no match
+    result = preact_iso_url_pattern_match("/", "/user/:id")
+    assert_nil result
+  end
+  
+  def test_rest_segment_match
+    # Rest segment - match
+    result = preact_iso_url_pattern_match("/user/foo", "/user/*")
+    expected = { 'params' => {}, 'rest' => '/foo' }
+    assert_equal expected, result
+  end
+  
+  def test_rest_segment_no_match
+    # Rest segment - no match
+    result = preact_iso_url_pattern_match("/", "/user/:id/*")
+    assert_nil result
+  end
+  
+  def test_param_with_rest_single_segment
+    # Param with rest - single segment
+    result = preact_iso_url_pattern_match("/user/2/foo", "/user/:id/*")
+    expected = { 'params' => { 'id' => '2' }, 'id' => '2', 'rest' => '/foo' }
+    assert_equal expected, result
+  end
+  
+  def test_param_with_rest_multiple_segments
+    # Param with rest - multiple segments
+    result = preact_iso_url_pattern_match("/user/2/foo/bar/bob", "/user/:id/*")
+    expected = { 'params' => { 'id' => '2' }, 'id' => '2', 'rest' => '/foo/bar/bob' }
+    assert_equal expected, result
+  end
+  
+  def test_optional_param_empty
+    # Optional param - empty
+    result = preact_iso_url_pattern_match("/user", "/user/:id?")
+    expected = { 'params' => { 'id' => nil }, 'id' => nil }
+    assert_equal expected, result
+  end
+  
+  def test_optional_param_no_match_base
+    # Optional param - no match base
+    result = preact_iso_url_pattern_match("/", "/user/:id?")
+    assert_nil result
+  end
+  
+  def test_optional_rest_param_empty
+    # Optional rest param - empty
+    result = preact_iso_url_pattern_match("/user", "/user/:id*")
+    expected = { 'params' => { 'id' => nil }, 'id' => nil }
+    assert_equal expected, result
+  end
+  
+  def test_optional_rest_param_with_segments
+    # Optional rest param - with segments
+    result = preact_iso_url_pattern_match("/user/foo/bar", "/user/:id*")
+    expected = { 'params' => { 'id' => 'foo/bar' }, 'id' => 'foo/bar' }
+    assert_equal expected, result
+  end
+  
+  def test_required_rest_param_single_segment
+    # Required rest param - single segment
+    result = preact_iso_url_pattern_match("/user/foo", "/user/:id+")
+    expected = { 'params' => { 'id' => 'foo' }, 'id' => 'foo' }
+    assert_equal expected, result
+  end
+  
+  def test_required_rest_param_multiple_segments
+    # Required rest param - multiple segments
+    result = preact_iso_url_pattern_match("/user/foo/bar", "/user/:id+")
+    expected = { 'params' => { 'id' => 'foo/bar' }, 'id' => 'foo/bar' }
+    assert_equal expected, result
+  end
+  
+  def test_required_rest_param_empty_should_fail
+    # Required rest param - empty (should fail)
+    result = preact_iso_url_pattern_match("/user", "/user/:id+")
+    assert_nil result
+  end
+  
+  def test_required_rest_param_root_mismatch
+    # Required rest param - root mismatch
+    result = preact_iso_url_pattern_match("/", "/user/:id+")
+    assert_nil result
+  end
+  
+  def test_leading_trailing_slashes
+    # Leading/trailing slashes
+    result = preact_iso_url_pattern_match("/about-late/_SEGMENT1_/_SEGMENT2_/", "/about-late/:seg1/:seg2/")
+    expected = { 'params' => { 'seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_' }, 'seg1' => '_SEGMENT1_', 'seg2' => '_SEGMENT2_' }
+    assert_equal expected, result
+  end
+  
+  def test_url_encoded_param
+    # URL encoded param
+    result = preact_iso_url_pattern_match("/foo/bar%20baz", "/foo/:param")
+    expected = { 'params' => { 'param' => 'bar baz' }, 'param' => 'bar baz' }
+    assert_equal expected, result
+  end
+  
+  def test_url_encoded_email_in_param
+    # URL encoded email in param
+    result = preact_iso_url_pattern_match("/users/test%40example.com/posts", "/users/:userId/posts")
+    expected = { 'params' => { 'userId' => 'test@example.com' }, 'userId' => 'test@example.com' }
+    assert_equal expected, result
+  end
+  
+  def test_rest_segment_with_encoded_parts
+    # Rest segment with encoded parts
+    result = preact_iso_url_pattern_match("/api/path/with%20spaces/and%2Fslashes", "/api/:path+")
+    expected = { 'params' => { 'path' => 'path/with spaces/and/slashes' }, 'path' => 'path/with spaces/and/slashes' }
+    assert_equal expected, result
+  end
+  
+  def test_empty_route
+    # Empty route
+    result = preact_iso_url_pattern_match("/foo", "")
+    assert_nil result
+  end
+  
+  def test_empty_url_with_param
+    # Empty url with param
+    result = preact_iso_url_pattern_match("", "/:param")
+    assert_nil result
+  end
+  
+  def test_multiple_optional_params
+    # Multiple optional params
+    result = preact_iso_url_pattern_match("/foo", "/:a?/:b?/:c?")
+    expected = { 'params' => { 'a' => 'foo', 'b' => nil, 'c' => nil }, 'a' => 'foo', 'b' => nil, 'c' => nil }
+    assert_equal expected, result
+  end
+  
+  def test_mixed_required_and_optional_params
+    # Mixed required and optional params
+    result = preact_iso_url_pattern_match("/foo/bar", "/:required/:optional?")
+    expected = { 'params' => { 'required' => 'foo', 'optional' => 'bar' }, 'required' => 'foo', 'optional' => 'bar' }
+    assert_equal expected, result
+  end
+  
+  def test_mixed_required_and_optional_params_missing_optional
+    # Mixed required and optional params - missing optional
+    result = preact_iso_url_pattern_match("/foo", "/:required/:optional?")
+    expected = { 'params' => { 'required' => 'foo', 'optional' => nil }, 'required' => 'foo', 'optional' => nil }
+    assert_equal expected, result
+  end
+  
+  def test_pre_existing_matches_object
+    # Pre-existing matches object
+    matches = { 'params' => { 'existing' => 'value' } }
+    result = preact_iso_url_pattern_match("/foo/bar", "/:first/:second", matches)
+    expected = { 'params' => { 'existing' => 'value', 'first' => 'foo', 'second' => 'bar' }, 'first' => 'foo', 'second' => 'bar' }
+    assert_equal expected, result
+  end
+  
+  def test_anonymous_wildcard_rest
+    # Anonymous wildcard rest
+    result = preact_iso_url_pattern_match("/static/css/main.css", "/static/*")
+    expected = { 'params' => {}, 'rest' => '/css/main.css' }
+    assert_equal expected, result
+  end
+  
+  def test_complex_nested_path_with_multiple_params
+    # Complex nested path with multiple params
+    result = preact_iso_url_pattern_match("/api/v1/users/123/posts/456/comments", "/api/:version/users/:userId/posts/:postId/comments")
+    expected = {
+      'params' => { 'version' => 'v1', 'userId' => '123', 'postId' => '456' },
+      'version' => 'v1', 'userId' => '123', 'postId' => '456'
+    }
+    assert_equal expected, result
+  end
+  
+  def test_route_longer_than_url_required_param_missing
+    # Route longer than URL - required param missing
+    result = preact_iso_url_pattern_match("/api", "/api/:version/:resource")
+    assert_nil result
+  end
+  
+  def test_route_longer_than_url_optional_param
+    # Route longer than URL - optional param
+    result = preact_iso_url_pattern_match("/api", "/api/:version?")
+    expected = { 'params' => { 'version' => nil }, 'version' => nil }
+    assert_equal expected, result
+  end
+  
+  def test_empty_string_should_be_handled_as_undefined_for_optional_rest
+    # Empty string should be handled as undefined for optional rest
+    result = preact_iso_url_pattern_match("/user", "/user/:id*")
+    expected = { 'params' => { 'id' => nil }, 'id' => nil }
+    assert_equal expected, result
+  end
+  
+  def test_multiple_slashes_in_url_should_be_normalized
+    # Multiple slashes in URL should be normalized
+    result = preact_iso_url_pattern_match("//user//123//", "/user/:id")
+    expected = { 'params' => { 'id' => '123' }, 'id' => '123' }
+    assert_equal expected, result
+  end
+  
+  def test_route_with_multiple_slashes
+    # Route with multiple slashes
+    result = preact_iso_url_pattern_match("/user/123", "//user//:id//")
+    expected = { 'params' => { 'id' => '123' }, 'id' => '123' }
+    assert_equal expected, result
+  end
+  
+  def test_special_characters_in_param_names
+    # Special characters in param names
+    result = preact_iso_url_pattern_match("/user/123", "/user/:user_id")
+    expected = { 'params' => { 'user_id' => '123' }, 'user_id' => '123' }
+    assert_equal expected, result
+  end
+  
+  def test_param_with_numbers
+    # Param with numbers
+    result = preact_iso_url_pattern_match("/api/v1", "/api/:version1")
+    expected = { 'params' => { 'version1' => 'v1' }, 'version1' => 'v1' }
+    assert_equal expected, result
+  end
+  
+  def test_rest_param_with_single_character
+    # Rest param with single character
+    result = preact_iso_url_pattern_match("/a/b", "/:x+")
+    expected = { 'params' => { 'x' => 'a/b' }, 'x' => 'a/b' }
+    assert_equal expected, result
+  end
+  
+  def test_complex_url_encoding_in_rest_params
+    # Complex URL encoding in rest params
+    result = preact_iso_url_pattern_match("/files/folder%2Fsubfolder/file%20name.txt", "/files/:path+")
+    expected = { 'params' => { 'path' => 'folder/subfolder/file name.txt' }, 'path' => 'folder/subfolder/file name.txt' }
+    assert_equal expected, result
+  end
+  
+  def test_question_mark_in_url_not_query_param
+    # Question mark in URL (not query param)
+    result = preact_iso_url_pattern_match("/search/what%3F", "/search/:query")
+    expected = { 'params' => { 'query' => 'what?' }, 'query' => 'what?' }
+    assert_equal expected, result
+  end
+  
+  def test_plus_sign_in_url
+    # Plus sign in URL
+    result = preact_iso_url_pattern_match("/math/1%2B1", "/math/:expression")
+    expected = { 'params' => { 'expression' => '1+1' }, 'expression' => '1+1' }
+    assert_equal expected, result
+  end
+  
+  def test_hash_in_url_encoded
+    # Hash in URL (encoded)
+    result = preact_iso_url_pattern_match("/tag/%23javascript", "/tag/:name")
+    expected = { 'params' => { 'name' => '#javascript' }, 'name' => '#javascript' }
+    assert_equal expected, result
+  end
+  
+  def test_ampersand_in_url
+    # Ampersand in URL
+    result = preact_iso_url_pattern_match("/search/cats%26dogs", "/search/:query")
+    expected = { 'params' => { 'query' => 'cats&dogs' }, 'query' => 'cats&dogs' }
+    assert_equal expected, result
+  end
+  
+  def test_unicode_characters
+    # Unicode characters
+    result = preact_iso_url_pattern_match("/user/José", "/user/:name")
+    expected = { 'params' => { 'name' => 'José' }, 'name' => 'José' }
+    assert_equal expected, result
+  end
+  
+  def test_unicode_characters_encoded
+    # Unicode characters encoded
+    result = preact_iso_url_pattern_match("/user/Jos%C3%A9", "/user/:name")
+    expected = { 'params' => { 'name' => 'José' }, 'name' => 'José' }
+    assert_equal expected, result
+  end
+  
+  def test_very_long_param
+    # Very long param
+    long_content = 'a' * 1000
+    result = preact_iso_url_pattern_match("/data/#{long_content}", "/data/:content")
+    expected = { 'params' => { 'content' => long_content }, 'content' => long_content }
+    assert_equal expected, result
+  end
+  
+  def test_empty_segments_in_middle_of_url
+    # Empty segments in middle of URL
+    result = preact_iso_url_pattern_match("/api//v1//users", "/api/v1/users")
+    expected = { 'params' => {} }
+    assert_equal expected, result
+  end
+  
+  def test_route_with_only_wildcards
+    # Route with only wildcards
+    result = preact_iso_url_pattern_match("/anything/goes/here", "*")
+    expected = { 'params' => {}, 'rest' => '/anything/goes/here' }
+    assert_equal expected, result
+  end
+  
+  def test_multiple_consecutive_optional_params
+    # Multiple consecutive optional params
+    result = preact_iso_url_pattern_match("/a/b", "/:first?/:second?/:third?/:fourth?")
+    expected = {
+      'params' => { 'first' => 'a', 'second' => 'b', 'third' => nil, 'fourth' => nil },
+      'first' => 'a', 'second' => 'b', 'third' => nil, 'fourth' => nil
+    }
+    assert_equal expected, result
+  end
+  
+  def test_zero_width_param_names_edge_case
+    # Zero-width param names (edge case)
+    result = preact_iso_url_pattern_match("/test", "/:?")
+    expected = { 'params' => { '' => 'test' }, '' => 'test' }
+    assert_equal expected, result
+  end
+end
+
+class TestUrlDecodingErrorHandling < Minitest::Test
+  # Tests specifically for URL decoding error scenarios
+  
+  def test_malformed_percent_encoding_simple_param
+    # Test malformed percent encoding in simple param - should not crash
+    # This should handle malformed encoding gracefully
+    result = preact_iso_url_pattern_match("/user/test%", "/user/:id")
+    # Should either work or return nil, but not crash
+    refute_nil result
+  end
+  
+  def test_malformed_percent_encoding_rest_param
+    # Test malformed percent encoding in rest param - should not crash
+    result = preact_iso_url_pattern_match("/files/test%/file", "/files/:path+")
+    # Should either work or return nil, but not crash
+    refute_nil result
+  end
+  
+  def test_invalid_unicode_sequence
+    # Test invalid unicode sequence - should not crash
+    result = preact_iso_url_pattern_match("/user/test%C3", "/user/:id")
+    # Should either work or return nil, but not crash
+    refute_nil result
+  end
+end
+
+# Run tests if this file is executed directly
+if __FILE__ == $0
+  puts "Running Ruby tests for preact-iso-url-pattern..."
+end

--- a/polyglot-utils/ruby/test_preact_iso_url_pattern.rb
+++ b/polyglot-utils/ruby/test_preact_iso_url_pattern.rb
@@ -6,6 +6,7 @@ require_relative 'preact-iso-url-pattern'
 
 class TestPreactIsoUrlPatternMatch < Minitest::Test
   
+  # Base route tests
   def test_base_route_exact_match
     # Base route - exact match
     result = preact_iso_url_pattern_match("/", "/")
@@ -19,6 +20,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_nil result
   end
   
+  # Param route tests
   def test_param_route_match
     # Param route - match
     result = preact_iso_url_pattern_match("/user/2", "/user/:id")
@@ -32,6 +34,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_nil result
   end
   
+  # Rest segment tests
   def test_rest_segment_match
     # Rest segment - match
     result = preact_iso_url_pattern_match("/user/foo", "/user/*")
@@ -58,6 +61,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_nil result
   end
   
+  # Param route with rest segment
   def test_param_with_rest_single_segment
     # Param with rest - single segment
     result = preact_iso_url_pattern_match("/user/2/foo", "/user/:id/*")
@@ -72,6 +76,13 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
+  def test_param_with_rest_no_match
+    # Param with rest - no match
+    result = preact_iso_url_pattern_match("/", "/user/:id/*")
+    assert_nil result
+  end
+  
+  # Optional param tests
   def test_optional_param_empty
     # Optional param - empty
     result = preact_iso_url_pattern_match("/user", "/user/:id?")
@@ -85,6 +96,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_nil result
   end
   
+  # Optional rest param tests (/:x*)
   def test_optional_rest_param_empty
     # Optional rest param - empty
     result = preact_iso_url_pattern_match("/user", "/user/:id*")
@@ -99,6 +111,13 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
+  def test_optional_param_no_match_base_duplicate
+    # Optional param - no match base duplicate
+    result = preact_iso_url_pattern_match("/", "/user/:id*")
+    assert_nil result
+  end
+  
+  # Required rest param tests (/:x+)
   def test_required_rest_param_single_segment
     # Required rest param - single segment
     result = preact_iso_url_pattern_match("/user/foo", "/user/:id+")
@@ -125,6 +144,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_nil result
   end
   
+  # Leading/trailing slashes
   def test_leading_trailing_slashes
     # Leading/trailing slashes
     result = preact_iso_url_pattern_match("/about-late/_SEGMENT1_/_SEGMENT2_/", "/about-late/:seg1/:seg2/")
@@ -132,6 +152,8 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
+  # Additional tests that are not in test/node/router-match.test.js
+  # URL encoding tests
   def test_url_encoded_param
     # URL encoded param
     result = preact_iso_url_pattern_match("/foo/bar%20baz", "/foo/:param")
@@ -146,6 +168,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
+  # Complex rest segment with encoding
   def test_rest_segment_with_encoded_parts
     # Rest segment with encoded parts
     result = preact_iso_url_pattern_match("/api/path/with%20spaces/and%2Fslashes", "/api/:path+")
@@ -153,6 +176,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
+  # Edge cases
   def test_empty_route
     # Empty route
     result = preact_iso_url_pattern_match("/foo", "")
@@ -163,13 +187,6 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     # Empty url with param
     result = preact_iso_url_pattern_match("", "/:param")
     assert_nil result
-  end
-  
-  def test_multiple_optional_params
-    # Multiple optional params
-    result = preact_iso_url_pattern_match("/foo", "/:a?/:b?/:c?")
-    expected = { 'params' => { 'a' => 'foo', 'b' => nil, 'c' => nil }, 'a' => 'foo', 'b' => nil, 'c' => nil }
-    assert_equal expected, result
   end
   
   def test_mixed_required_and_optional_params
@@ -186,6 +203,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
+  # Test with pre-existing matches
   def test_pre_existing_matches_object
     # Pre-existing matches object
     matches = { 'params' => { 'existing' => 'value' } }
@@ -193,14 +211,8 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'existing' => 'value', 'first' => 'foo', 'second' => 'bar' }, 'first' => 'foo', 'second' => 'bar' }
     assert_equal expected, result
   end
-  
-  def test_anonymous_wildcard_rest
-    # Anonymous wildcard rest
-    result = preact_iso_url_pattern_match("/static/css/main.css", "/static/*")
-    expected = { 'params' => {}, 'rest' => '/css/main.css' }
-    assert_equal expected, result
-  end
-  
+
+  # Complex nested paths
   def test_complex_nested_path_with_multiple_params
     # Complex nested path with multiple params
     result = preact_iso_url_pattern_match("/api/v1/users/123/posts/456/comments", "/api/:version/users/:userId/posts/:postId/comments")
@@ -224,13 +236,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
-  def test_empty_string_should_be_handled_as_undefined_for_optional_rest
-    # Empty string should be handled as undefined for optional rest
-    result = preact_iso_url_pattern_match("/user", "/user/:id*")
-    expected = { 'params' => { 'id' => nil }, 'id' => nil }
-    assert_equal expected, result
-  end
-  
+
   def test_multiple_slashes_in_url_should_be_normalized
     # Multiple slashes in URL should be normalized
     result = preact_iso_url_pattern_match("//user//123//", "/user/:id")
@@ -244,21 +250,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'id' => '123' }, 'id' => '123' }
     assert_equal expected, result
   end
-  
-  def test_special_characters_in_param_names
-    # Special characters in param names
-    result = preact_iso_url_pattern_match("/user/123", "/user/:user_id")
-    expected = { 'params' => { 'user_id' => '123' }, 'user_id' => '123' }
-    assert_equal expected, result
-  end
-  
-  def test_param_with_numbers
-    # Param with numbers
-    result = preact_iso_url_pattern_match("/api/v1", "/api/:version1")
-    expected = { 'params' => { 'version1' => 'v1' }, 'version1' => 'v1' }
-    assert_equal expected, result
-  end
-  
+
   def test_rest_param_with_single_character
     # Rest param with single character
     result = preact_iso_url_pattern_match("/a/b", "/:x+")
@@ -273,38 +265,10 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
-  def test_question_mark_in_url_not_query_param
-    # Question mark in URL (not query param)
-    result = preact_iso_url_pattern_match("/search/what%3F", "/search/:query")
-    expected = { 'params' => { 'query' => 'what?' }, 'query' => 'what?' }
-    assert_equal expected, result
-  end
-  
-  def test_plus_sign_in_url
-    # Plus sign in URL
-    result = preact_iso_url_pattern_match("/math/1%2B1", "/math/:expression")
-    expected = { 'params' => { 'expression' => '1+1' }, 'expression' => '1+1' }
-    assert_equal expected, result
-  end
-  
-  def test_hash_in_url_encoded
-    # Hash in URL (encoded)
-    result = preact_iso_url_pattern_match("/tag/%23javascript", "/tag/:name")
-    expected = { 'params' => { 'name' => '#javascript' }, 'name' => '#javascript' }
-    assert_equal expected, result
-  end
-  
-  def test_ampersand_in_url
-    # Ampersand in URL
-    result = preact_iso_url_pattern_match("/search/cats%26dogs", "/search/:query")
-    expected = { 'params' => { 'query' => 'cats&dogs' }, 'query' => 'cats&dogs' }
-    assert_equal expected, result
-  end
-  
-  def test_unicode_characters
-    # Unicode characters
-    result = preact_iso_url_pattern_match("/user/José", "/user/:name")
-    expected = { 'params' => { 'name' => 'José' }, 'name' => 'José' }
+  def test_special_characters_encoded_in_url
+    # Special characters encoded in URL
+    result = preact_iso_url_pattern_match("/search/query%3F%2B%23%26test", "/search/:query")
+    expected = { 'params' => { 'query' => 'query?+#&test' }, 'query' => 'query?+#&test' }
     assert_equal expected, result
   end
   
@@ -314,15 +278,7 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     expected = { 'params' => { 'name' => 'José' }, 'name' => 'José' }
     assert_equal expected, result
   end
-  
-  def test_very_long_param
-    # Very long param
-    long_content = 'a' * 1000
-    result = preact_iso_url_pattern_match("/data/#{long_content}", "/data/:content")
-    expected = { 'params' => { 'content' => long_content }, 'content' => long_content }
-    assert_equal expected, result
-  end
-  
+
   def test_empty_segments_in_middle_of_url
     # Empty segments in middle of URL
     result = preact_iso_url_pattern_match("/api//v1//users", "/api/v1/users")
@@ -337,22 +293,6 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
-  def test_multiple_consecutive_optional_params
-    # Multiple consecutive optional params
-    result = preact_iso_url_pattern_match("/a/b", "/:first?/:second?/:third?/:fourth?")
-    expected = {
-      'params' => { 'first' => 'a', 'second' => 'b', 'third' => nil, 'fourth' => nil },
-      'first' => 'a', 'second' => 'b', 'third' => nil, 'fourth' => nil
-    }
-    assert_equal expected, result
-  end
-  
-  def test_zero_width_param_names_edge_case
-    # Zero-width param names (edge case)
-    result = preact_iso_url_pattern_match("/test", "/:?")
-    expected = { 'params' => { '' => 'test' }, '' => 'test' }
-    assert_equal expected, result
-  end
 end
 
 class TestUrlDecodingErrorHandling < Minitest::Test

--- a/polyglot-utils/ruby/test_preact_iso_url_pattern.rb
+++ b/polyglot-utils/ruby/test_preact_iso_url_pattern.rb
@@ -39,8 +39,21 @@ class TestPreactIsoUrlPatternMatch < Minitest::Test
     assert_equal expected, result
   end
   
+  def test_rest_segment_match_multiple_segments
+    # Rest segment - match multiple segments
+    result = preact_iso_url_pattern_match("/user/foo/bar/baz", "/user/*")
+    expected = { 'params' => {}, 'rest' => '/foo/bar/baz' }
+    assert_equal expected, result
+  end
+  
   def test_rest_segment_no_match
     # Rest segment - no match
+    result = preact_iso_url_pattern_match("/user", "/user/*")
+    assert_nil result
+  end
+  
+  def test_rest_segment_no_match_different_case
+    # Rest segment - no match different case
     result = preact_iso_url_pattern_match("/", "/user/:id/*")
     assert_nil result
   end

--- a/polyglot-utils/run_tests.sh
+++ b/polyglot-utils/run_tests.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Preact ISO URL Pattern Matching - Test Runner  
+# Runs tests for all language implementations
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Track test results
+TOTAL_LANGUAGES=4
+PASSED_LANGUAGES=0
+
+echo "========================================"
+echo "Preact ISO URL Pattern - Test Runner"
+echo "========================================"
+echo
+
+# Function to run a test and track results
+run_test() {
+    local language=$1
+    local directory=$2
+    local command=$3
+    local description=$4
+    
+    echo -e "${BLUE}Testing $language${NC} ($description)"
+    echo "----------------------------------------"
+    
+    # Change to test directory and run command
+    if cd "$directory" 2>/dev/null; then
+        if eval "$command"; then
+            echo -e "${GREEN}$language tests PASSED${NC}"
+            ((PASSED_LANGUAGES++))
+        else
+            echo -e "${RED}$language tests FAILED${NC}"
+        fi
+    else
+        echo -e "${RED}$language tests FAILED - Directory not found${NC}"
+    fi
+    
+    echo
+    # Return to script directory
+    cd "$SCRIPT_DIR" 2>/dev/null || true
+}
+
+# Get the script directory to ensure we're in the right place
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Run tests for each language
+run_test "Go" "go" "go test -v" "Static typing with struct returns"
+run_test "Python" "python" "python3 test_preact_iso_url_pattern.py" "Dictionary-based with optional typing"
+run_test "Ruby" "ruby" "ruby test_preact_iso_url_pattern.rb" "Hash-based with flexible syntax"
+run_test "PHP" "php" "php test_preact_iso_url_pattern.php" "Mixed array/object approach"
+
+# Summary
+echo "========================================"
+echo "Test Summary"
+echo "========================================"
+
+if [ $PASSED_LANGUAGES -eq $TOTAL_LANGUAGES ]; then
+    echo -e "${GREEN}All $TOTAL_LANGUAGES language implementations passed their tests!${NC}"
+    echo -e "${GREEN}Total tests across all languages: 204 (51 × 4)${NC}"
+    exit 0
+else
+    echo -e "${RED}$PASSED_LANGUAGES/$TOTAL_LANGUAGES language implementations passed${NC}"
+    echo -e "${RED}$(($TOTAL_LANGUAGES - $PASSED_LANGUAGES)) language(s) failed${NC}"
+    exit 1
+fi

--- a/polyglot-utils/run_tests.sh
+++ b/polyglot-utils/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Preact ISO URL Pattern Matching - Test Runner  
+# Preact ISO URL Pattern Matching - Test Runner
 # Runs tests for all language implementations
 
 # Colors for output
@@ -25,10 +25,10 @@ run_test() {
     local directory=$2
     local command=$3
     local description=$4
-    
+
     echo -e "${BLUE}Testing $language${NC} ($description)"
     echo "----------------------------------------"
-    
+
     # Change to test directory and run command
     if cd "$directory" 2>/dev/null; then
         if eval "$command"; then
@@ -40,7 +40,7 @@ run_test() {
     else
         echo -e "${RED}$language tests FAILED - Directory not found${NC}"
     fi
-    
+
     echo
     # Return to script directory
     cd "$SCRIPT_DIR" 2>/dev/null || true

--- a/test/node/router-match.test.js
+++ b/test/node/router-match.test.js
@@ -71,6 +71,8 @@ test('Optional rest param route "/:x*"', () => {
 		query: {}
 	});
 
+	// TODO: This test is exactly same as the above test?
+	// `const matchedResult = execPath('/user', '/user/:id*');`
 	const emptyResult = execPath('/user', '/user/:id*');
 	assert.equal(emptyResult, {
 		path: '/user',

--- a/test/node/router-match.test.js
+++ b/test/node/router-match.test.js
@@ -71,8 +71,6 @@ test('Optional rest param route "/:x*"', () => {
 		query: {}
 	});
 
-	// TODO: This test is exactly same as the above test?
-	// `const matchedResult = execPath('/user', '/user/:id*');`
 	const emptyResult = execPath('/user', '/user/:id*');
 	assert.equal(emptyResult, {
 		path: '/user',


### PR DESCRIPTION
Implemented router's URL matching logic in multiple (non-JS) languages. Since those languages cannot do SSR / prerendering without a JS engine, they can still do simpler optimizations. Use cases in mind:

- Preloading of static assets (JS, CSS, images, icons)
- Early return of 404 page
- Light SEO: e.g. Move page title tag info etc into a client-side routes file, but yet have it in the HTML loaded from server 