### PR TITLE
fix: Ensure params aren't copied between partial matches

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -158,7 +158,17 @@ export function Router(props) {
 
 	let pathRoute, defaultRoute, matchProps;
 	toChildArray(props.children).some((/** @type {VNode<any>} */ vnode) => {
-		const matches = exec(rest, vnode.props.path, (matchProps = { ...vnode.props, path: rest, query, params, rest: '' }));
+		const matches = exec(
+			rest,
+			vnode.props.path,
+			(matchProps = {
+				...vnode.props,
+				path: rest,
+				query,
+				params: Object.assign({}, params),
+				rest: ''
+			})
+		);
 		if (matches) return (pathRoute = cloneElement(vnode, matchProps));
 		if (vnode.props.default) defaultRoute = cloneElement(vnode, matchProps);
 	});


### PR DESCRIPTION
Fixes #123

Because each call of `exec` shared the same `params` obj, partial matches could get carried between attempts to find a matching child.

```jsx
<Route path="/category/:id" component={Params} />
<Route path="/category/:categoryId/products/new" component={Params} />
```

When trying to load `'/category/123/products/new'`, it'd test the first route, setting params up as `{ id: '123' }`, and when that failed, the same `params` object was passed to the second test. It of course would match, but the params object would end up as `{ id: '123', categoryId: '123' }`, keeping the incorrect `id` from the previous failed match.