### PR TITLE
fix: Eliminate TS2312 error in router.d.ts

### DIFF
--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -88,8 +88,15 @@ export type RoutePropsForPath<Path extends string> = Path extends '*'
 export function Route<Props>(props: RouteProps<Props> & Partial<Props>): VNode;
 
 declare module 'preact' {
+	// The code below automatically adds `path` and `default` as optional props for every component
+	// (effectively reserving those names, so no component should use those names in its own props).
+	// These declarations extend from `RouteableProps`, which is not allowed in modern TypeScript and
+	// causes a TS2312 error.  However, the compiler does seems to honor the intent of this code, so
+	// to avoid an API regression, let's ignore the error rather than loosening the type validation.
 	namespace JSX {
+		/** @ts-ignore */
 		interface IntrinsicAttributes extends RoutableProps {}
 	}
+	/** @ts-ignore */
 	interface Attributes extends RoutableProps {}
 }


### PR DESCRIPTION
This is a fix for https://github.com/preactjs/preact-iso/issues/129 and https://github.com/preactjs/preact-iso/issues/94

If we wanted to be more correct but less ergonomic, an alternate possibility would be:

```typescript
// A simplified version of RoutableProps that can be used with "extends"
interface JsxRoutableProps {
	path?: string;
	default?:boolean
}	

declare module 'preact' {
	namespace JSX {
		interface IntrinsicAttributes extends JsxRoutableProps {}
	}
	interface Attributes extends JsxRoutableProps {}
}
```

@rschristian @aymericzip

