### PR TITLE
feat: add viewTransition prop to Router

### DIFF
--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -32,6 +32,7 @@ type MatchProps = KnownProps & ArbitraryProps;
 export function exec(url: string, route: string, matches?: MatchProps): MatchProps
 
 export function Router(props: {
+	viewTransition?: boolean;
 	onRouteChange?: (url: string) => void;
 	onLoadEnd?: (url: string) => void;
 	onLoadStart?: (url: string) => void;

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,5 @@
 import { h, createContext, cloneElement, toChildArray } from 'preact';
-import { useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'preact/hooks';
+import { useContext, useCallback, useMemo, useReducer, useLayoutEffect, useRef } from 'preact/hooks';
 
 /**
  * @template T
@@ -11,6 +11,8 @@ import { useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'preact
 let push;
 /** @type {string | RegExp | undefined} */
 let scope;
+/** @type {boolean | undefined} */
+let viewTransition;
 
 /**
  * @param {string} href
@@ -24,44 +26,43 @@ function isInScope(href) {
 }
 
 /**
- * @param {string} state
- * @param {MouseEvent | PopStateEvent | { url: string, replace?: boolean }} action
+ * Resolve a click event into a navigation URL, or return null if the click should be ignored.
+ * Calls preventDefault() synchronously for intercepted clicks.
+ * @param {MouseEvent} event
+ * @returns {{ url: string } | null}
  */
-function handleNav(state, action) {
-	let url = '';
-	push = undefined;
-	if (action && action.type === 'click') {
-		// ignore events the browser takes care of already:
-		if (action.ctrlKey || action.metaKey || action.altKey || action.shiftKey || action.button !== 0) {
-			return state;
-		}
-
-		const link = action.composedPath().find(el => el.nodeName == 'A' && el.href),
-			href = link && link.getAttribute('href');
-		if (
-			!link ||
-			link.origin != location.origin ||
-			/^#/.test(href) ||
-			!/^(_?self)?$/i.test(link.target) ||
-			!isInScope(href) ||
-			link.download
-		) {
-			return state;
-		}
-
-		push = true;
-		action.preventDefault();
-		url = link.href.replace(location.origin, '');
-	} else if (action && action.url) {
-		push = !action.replace;
-		url = action.url;
-	} else {
-		url = location.pathname + location.search;
+function resolveClickNav(event) {
+	// ignore events the browser takes care of already:
+	if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey || event.button !== 0) {
+		return null;
 	}
 
-	if (push === true) history.pushState(null, '', url);
-	else if (push === false) history.replaceState(null, '', url);
-	return url;
+	const link = event.composedPath().find(el => el.nodeName == 'A' && el.href),
+		href = link && link.getAttribute('href');
+	if (
+		!link ||
+		link.origin != location.origin ||
+		/^#/.test(href) ||
+		!/^(_?self)?$/i.test(link.target) ||
+		!isInScope(href) ||
+		link.download
+	) {
+		return null;
+	}
+
+	event.preventDefault();
+	return { url: link.href.replace(location.origin, '') };
+}
+
+/**
+ * @param {string} state
+ * @param {{ url: string, _push?: boolean }} action
+ */
+function handleNav(state, action) {
+	push = action._push;
+	if (push === true) history.pushState(null, '', action.url);
+	else if (push === false) history.replaceState(null, '', action.url);
+	return action.url;
 };
 
 export const exec = (url, route, matches = {}) => {
@@ -99,9 +100,44 @@ export const exec = (url, route, matches = {}) => {
  */
 export function LocationProvider(props) {
 	// @ts-expect-error - props.url is not implemented correctly & will be removed in the future
-	const [url, route] = useReducer(handleNav, props.url || location.pathname + location.search);
-	if (props.scope) scope = props.scope;
+	const [url, update] = useReducer(handleNav, props.url || location.pathname + location.search);
+	scope = props.scope;
 	const wasPush = push === true;
+
+	const route = useCallback(
+		/**
+		 * @param {MouseEvent | PopStateEvent | { url: string, replace?: boolean }} action
+		 */
+		(action) => {
+			/** @type {string} */
+			let url;
+			/** @type {boolean | undefined} */
+			let shouldPush;
+
+			if (action && action.type === 'click') {
+				const nav = resolveClickNav(/** @type {MouseEvent} */ (action));
+				if (!nav) return;
+				url = nav.url;
+				shouldPush = true;
+			} else if (action && action.url) {
+				url = action.url;
+				shouldPush = !action.replace;
+			} else {
+				// popstate
+				url = location.pathname + location.search;
+				shouldPush = undefined;
+			}
+
+			const commit = () => update({ url, _push: shouldPush });
+
+			if (viewTransition && document.startViewTransition) {
+				document.startViewTransition(() => commit());
+			} else {
+				commit();
+			}
+		},
+		[]
+	);
 
 	const value = useMemo(() => {
 		const u = new URL(url, location.origin);
@@ -134,6 +170,7 @@ const RESOLVED = Promise.resolve();
 /** @this {import('./internal.d.ts').AugmentedComponent} */
 export function Router(props) {
 	const [c, update] = useReducer(c => c + 1, 0);
+	viewTransition = props.viewTransition;
 
 	const { url, query, wasPush, path } = useLocation();
 	if (!url) {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1060,6 +1060,138 @@ describe('Router', () => {
 	});
 });
 
+describe('viewTransition', () => {
+	let scratch, loc;
+
+	const ShallowLocation = () => {
+		loc = useLocation();
+		return null;
+	};
+
+	beforeEach(() => {
+		if (scratch) {
+			render(null, scratch);
+			scratch.remove();
+		}
+		// Clean up any leftover scratch elements from other test suites
+		let existing;
+		while ((existing = document.querySelector('scratch'))) {
+			render(null, existing);
+			existing.remove();
+		}
+		loc = undefined;
+		scratch = document.createElement('scratch');
+		document.body.appendChild(scratch);
+		history.replaceState(null, null, '/');
+	});
+
+	it('should not call startViewTransition when viewTransition is not set', async () => {
+		const startViewTransition = sinon.stub(document, 'startViewTransition').callsFake(cb => cb());
+		const Home = sinon.fake(() => <h1>Home</h1>);
+		const About = sinon.fake(() => <h1>About</h1>);
+
+		render(
+			<LocationProvider>
+				<Router>
+					<Home path="/" />
+					<About path="/about" />
+				</Router>
+				<ShallowLocation />
+			</LocationProvider>,
+			scratch
+		);
+
+		startViewTransition.resetHistory();
+		loc.route('/about');
+		await sleep(1);
+
+		expect(startViewTransition).not.to.have.been.called;
+		expect(scratch).to.have.property('textContent', 'About');
+
+		startViewTransition.restore();
+	});
+
+	it('should wrap navigation in startViewTransition when enabled', async () => {
+		const startViewTransition = sinon.stub(document, 'startViewTransition').callsFake(cb => cb());
+		const Home = sinon.fake(() => <h1>Home</h1>);
+		const About = sinon.fake(() => <h1>About</h1>);
+
+		render(
+			<LocationProvider>
+				<Router viewTransition>
+					<Home path="/" />
+					<About path="/about" />
+				</Router>
+				<ShallowLocation />
+			</LocationProvider>,
+			scratch
+		);
+
+		startViewTransition.resetHistory();
+		loc.route('/about');
+		await sleep(1);
+
+		expect(startViewTransition).to.have.been.calledOnce;
+		expect(scratch).to.have.property('textContent', 'About');
+		expect(loc).to.deep.include({ url: '/about', path: '/about' });
+
+		startViewTransition.restore();
+	});
+
+	it('should wrap <a> tag click navigation in startViewTransition', async () => {
+		const startViewTransition = sinon.stub(document, 'startViewTransition').callsFake(cb => cb());
+		const Home = sinon.fake(() => <div><a href="/about">Go</a></div>);
+		const About = sinon.fake(() => <h1>About</h1>);
+
+		render(
+			<LocationProvider>
+				<Router viewTransition>
+					<Home path="/" />
+					<About path="/about" />
+				</Router>
+				<ShallowLocation />
+			</LocationProvider>,
+			scratch
+		);
+
+		startViewTransition.resetHistory();
+		scratch.querySelector('a[href="/about"]').click();
+		await sleep(1);
+
+		expect(startViewTransition).to.have.been.calledOnce;
+		expect(scratch).to.have.property('textContent', 'About');
+
+		startViewTransition.restore();
+	});
+
+	it('should fall back to normal navigation when startViewTransition is not supported', async () => {
+		const original = document.startViewTransition;
+		document.startViewTransition = undefined;
+
+		const Home = sinon.fake(() => <h1>Home</h1>);
+		const About = sinon.fake(() => <h1>About</h1>);
+
+		render(
+			<LocationProvider>
+				<Router viewTransition>
+					<Home path="/" />
+					<About path="/about" />
+				</Router>
+				<ShallowLocation />
+			</LocationProvider>,
+			scratch
+		);
+
+		loc.route('/about');
+		await sleep(1);
+
+		expect(scratch).to.have.property('textContent', 'About');
+		expect(loc).to.deep.include({ url: '/about', path: '/about' });
+
+		document.startViewTransition = original;
+	});
+});
+
 const MODE_HYDRATE = 1 << 5;
 const MODE_SUSPENDED = 1 << 7;
 


### PR DESCRIPTION
Wraps route navigations in document.startViewTransition() when enabled, allowing CSS-driven animations between routes. Falls back to normal navigation when the API is not available.