### PR TITLE
feat: add onBeforeRouteChange callback to Router

### DIFF
--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -32,6 +32,7 @@ type MatchProps = KnownProps & ArbitraryProps;
 export function exec(url: string, route: string, matches?: MatchProps): MatchProps
 
 export function Router(props: {
+	onBeforeRouteChange?: (url: string, proceed: () => void) => void;
 	onRouteChange?: (url: string) => void;
 	onLoadEnd?: (url: string) => void;
 	onLoadStart?: (url: string) => void;

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,5 @@
 import { h, createContext, cloneElement, toChildArray } from 'preact';
-import { useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'preact/hooks';
+import { useContext, useCallback, useMemo, useReducer, useLayoutEffect, useRef } from 'preact/hooks';
 
 /**
  * @template T
@@ -11,6 +11,8 @@ import { useContext, useMemo, useReducer, useLayoutEffect, useRef } from 'preact
 let push;
 /** @type {string | RegExp | undefined} */
 let scope;
+/** @type {((url: string, proceed: () => void) => void) | undefined} */
+let beforeRouteChange;
 
 /**
  * @param {string} href
@@ -24,44 +26,43 @@ function isInScope(href) {
 }
 
 /**
- * @param {string} state
- * @param {MouseEvent | PopStateEvent | { url: string, replace?: boolean }} action
+ * Resolve a click event into a navigation URL, or return null if the click should be ignored.
+ * Calls preventDefault() synchronously for intercepted clicks.
+ * @param {MouseEvent} event
+ * @returns {{ url: string } | null}
  */
-function handleNav(state, action) {
-	let url = '';
-	push = undefined;
-	if (action && action.type === 'click') {
-		// ignore events the browser takes care of already:
-		if (action.ctrlKey || action.metaKey || action.altKey || action.shiftKey || action.button !== 0) {
-			return state;
-		}
-
-		const link = action.composedPath().find(el => el.nodeName == 'A' && el.href),
-			href = link && link.getAttribute('href');
-		if (
-			!link ||
-			link.origin != location.origin ||
-			/^#/.test(href) ||
-			!/^(_?self)?$/i.test(link.target) ||
-			!isInScope(href) ||
-			link.download
-		) {
-			return state;
-		}
-
-		push = true;
-		action.preventDefault();
-		url = link.href.replace(location.origin, '');
-	} else if (action && action.url) {
-		push = !action.replace;
-		url = action.url;
-	} else {
-		url = location.pathname + location.search;
+function resolveClickNav(event) {
+	// ignore events the browser takes care of already:
+	if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey || event.button !== 0) {
+		return null;
 	}
 
-	if (push === true) history.pushState(null, '', url);
-	else if (push === false) history.replaceState(null, '', url);
-	return url;
+	const link = event.composedPath().find(el => el.nodeName == 'A' && el.href),
+		href = link && link.getAttribute('href');
+	if (
+		!link ||
+		link.origin != location.origin ||
+		/^#/.test(href) ||
+		!/^(_?self)?$/i.test(link.target) ||
+		!isInScope(href) ||
+		link.download
+	) {
+		return null;
+	}
+
+	event.preventDefault();
+	return { url: link.href.replace(location.origin, '') };
+}
+
+/**
+ * @param {string} state
+ * @param {{ url: string, _push?: boolean }} action
+ */
+function handleNav(state, action) {
+	push = action._push;
+	if (push === true) history.pushState(null, '', action.url);
+	else if (push === false) history.replaceState(null, '', action.url);
+	return action.url;
 };
 
 export const exec = (url, route, matches = {}) => {
@@ -99,9 +100,49 @@ export const exec = (url, route, matches = {}) => {
  */
 export function LocationProvider(props) {
 	// @ts-expect-error - props.url is not implemented correctly & will be removed in the future
-	const [url, route] = useReducer(handleNav, props.url || location.pathname + location.search);
-	if (props.scope) scope = props.scope;
+	const [url, update] = useReducer(handleNav, props.url || location.pathname + location.search);
+	scope = props.scope;
 	const wasPush = push === true;
+
+	const route = useCallback(
+		/**
+		 * @param {MouseEvent | PopStateEvent | { url: string, replace?: boolean }} action
+		 */
+		(action) => {
+			/** @type {string} */
+			let url;
+			/** @type {boolean | undefined} */
+			let shouldPush;
+
+			if (action && action.type === 'click') {
+				const nav = resolveClickNav(/** @type {MouseEvent} */ (action));
+				if (!nav) return;
+				url = nav.url;
+				shouldPush = true;
+			} else if (action && action.url) {
+				url = action.url;
+				shouldPush = !action.replace;
+			} else {
+				// popstate
+				url = location.pathname + location.search;
+				shouldPush = undefined;
+			}
+
+			const commit = () => update({ url, _push: shouldPush });
+
+			if (beforeRouteChange) {
+				let called = false;
+				beforeRouteChange(url, () => {
+					if (called) return;
+					called = true;
+					commit();
+				});
+			} else {
+				commit();
+			}
+		},
+		[]
+	);
 
 	const value = useMemo(() => {
 		const u = new URL(url, location.origin);
@@ -134,6 +175,7 @@ const RESOLVED = Promise.resolve();
 /** @this {import('./internal.d.ts').AugmentedComponent} */
 export function Router(props) {
 	const [c, update] = useReducer(c => c + 1, 0);
+	beforeRouteChange = props.onBeforeRouteChange;
 
 	const { url, query, wasPush, path } = useLocation();
 	if (!url) {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1060,6 +1060,224 @@ describe('Router', () => {
 	});
 });
 
+describe('onBeforeRouteChange', () => {
+	let scratch, loc;
+
+	const ShallowLocation = () => {
+		loc = useLocation();
+		return null;
+	};
+
+	beforeEach(() => {
+		if (scratch) {
+			render(null, scratch);
+			scratch.remove();
+		}
+		// Clean up any leftover scratch elements from other test suites
+		let existing;
+		while ((existing = document.querySelector('scratch'))) {
+			render(null, existing);
+			existing.remove();
+		}
+		loc = undefined;
+		scratch = document.createElement('scratch');
+		document.body.appendChild(scratch);
+		history.replaceState(null, null, '/');
+	});
+
+	it('should navigate normally when proceed() is called synchronously', async () => {
+		const beforeChange = sinon.fake((url, proceed) => proceed());
+		const Home = sinon.fake(() => h('h1', null, 'Home'));
+		const About = sinon.fake(() => h('h1', null, 'About'));
+
+		render(
+			h(LocationProvider, null,
+				h(Router, { onBeforeRouteChange: beforeChange },
+					h(Home, { path: '/' }),
+					h(About, { path: '/about' })
+				),
+				h(ShallowLocation)
+			),
+			scratch
+		);
+
+		expect(scratch).to.have.property('textContent', 'Home');
+		beforeChange.resetHistory();
+
+		loc.route('/about');
+		await sleep(1);
+
+		expect(beforeChange).to.have.been.calledOnce;
+		expect(beforeChange.firstCall.args[0]).to.equal('/about');
+		expect(typeof beforeChange.firstCall.args[1]).to.equal('function');
+		expect(scratch).to.have.property('textContent', 'About');
+		expect(loc).to.deep.include({ url: '/about', path: '/about' });
+	});
+
+	it('should defer navigation until proceed() is called', async () => {
+		let savedProceed;
+		const beforeChange = sinon.fake((url, proceed) => {
+			savedProceed = proceed;
+		});
+		const Home = sinon.fake(() => h('h1', null, 'Home'));
+		const About = sinon.fake(() => h('h1', null, 'About'));
+
+		render(
+			h(LocationProvider, null,
+				h(Router, { onBeforeRouteChange: beforeChange },
+					h(Home, { path: '/' }),
+					h(About, { path: '/about' })
+				),
+				h(ShallowLocation)
+			),
+			scratch
+		);
+
+		expect(scratch).to.have.property('textContent', 'Home');
+		beforeChange.resetHistory();
+
+		loc.route('/about');
+		await sleep(1);
+
+		expect(beforeChange).to.have.been.calledOnce;
+		expect(scratch).to.have.property('textContent', 'Home');
+		expect(loc).to.deep.include({ path: '/' });
+
+		savedProceed();
+		await sleep(1);
+
+		expect(scratch).to.have.property('textContent', 'About');
+		expect(loc).to.deep.include({ url: '/about', path: '/about' });
+	});
+
+	it('should fire for <a> tag click navigation', async () => {
+		const beforeChange = sinon.fake((url, proceed) => proceed());
+		const Home = sinon.fake(() => h('div', null, h('a', { href: '/about' }, 'Go')));
+		const About = sinon.fake(() => h('h1', null, 'About'));
+
+		render(
+			h(LocationProvider, null,
+				h(Router, { onBeforeRouteChange: beforeChange },
+					h(Home, { path: '/' }),
+					h(About, { path: '/about' })
+				),
+				h(ShallowLocation)
+			),
+			scratch
+		);
+
+		expect(scratch).to.have.property('textContent', 'Go');
+		beforeChange.resetHistory();
+
+		scratch.querySelector('a[href="/about"]').click();
+		await sleep(1);
+
+		expect(beforeChange).to.have.been.calledOnce;
+		expect(beforeChange.firstCall.args[0]).to.equal('/about');
+		expect(scratch).to.have.property('textContent', 'About');
+	});
+
+	it('should fire before onRouteChange', async () => {
+		const callOrder = [];
+		const beforeChange = sinon.fake((url, proceed) => {
+			callOrder.push('before');
+			proceed();
+		});
+		const routeChange = sinon.fake(() => {
+			callOrder.push('after');
+		});
+		const Home = sinon.fake(() => h('h1', null, 'Home'));
+		const About = sinon.fake(() => h('h1', null, 'About'));
+
+		render(
+			h(LocationProvider, null,
+				h(Router, { onBeforeRouteChange: beforeChange, onRouteChange: routeChange },
+					h(Home, { path: '/' }),
+					h(About, { path: '/about' })
+				),
+				h(ShallowLocation)
+			),
+			scratch
+		);
+
+		beforeChange.resetHistory();
+		routeChange.resetHistory();
+
+		loc.route('/about');
+		await sleep(1);
+
+		expect(beforeChange).to.have.been.calledOnce;
+		expect(routeChange).to.have.been.calledOnce;
+		expect(callOrder).to.eql(['before', 'after']);
+	});
+
+	it('should cancel navigation when proceed() is never called', async () => {
+		const beforeChange = sinon.fake(() => { /* intentionally not calling proceed */ });
+		const Home = sinon.fake(() => h('h1', null, 'Home'));
+		const About = sinon.fake(() => h('h1', null, 'About'));
+
+		render(
+			h(LocationProvider, null,
+				h(Router, { onBeforeRouteChange: beforeChange },
+					h(Home, { path: '/' }),
+					h(About, { path: '/about' })
+				),
+				h(ShallowLocation)
+			),
+			scratch
+		);
+
+		expect(scratch).to.have.property('textContent', 'Home');
+		beforeChange.resetHistory();
+		Home.resetHistory();
+
+		loc.route('/about');
+		await sleep(10);
+
+		expect(beforeChange).to.have.been.calledOnce;
+		expect(scratch).to.have.property('textContent', 'Home');
+		expect(loc).to.deep.include({ path: '/' });
+		expect(About).not.to.have.been.called;
+	});
+
+	it('should only navigate once when proceed() is called multiple times', async () => {
+		const pushState = sinon.spy(history, 'pushState');
+		let savedProceed;
+		const beforeChange = sinon.fake((url, proceed) => {
+			savedProceed = proceed;
+		});
+		const Home = sinon.fake(() => h('h1', null, 'Home'));
+		const About = sinon.fake(() => h('h1', null, 'About'));
+
+		render(
+			h(LocationProvider, null,
+				h(Router, { onBeforeRouteChange: beforeChange },
+					h(Home, { path: '/' }),
+					h(About, { path: '/about' })
+				),
+				h(ShallowLocation)
+			),
+			scratch
+		);
+
+		beforeChange.resetHistory();
+
+		loc.route('/about');
+		await sleep(1);
+
+		pushState.resetHistory();
+		savedProceed();
+		savedProceed();
+		savedProceed();
+		await sleep(1);
+
+		expect(pushState).to.have.been.calledOnce;
+		expect(scratch).to.have.property('textContent', 'About');
+
+		pushState.restore();
+	});
+});
+
 const MODE_HYDRATE = 1 << 5;
 const MODE_SUSPENDED = 1 << 7;
 


### PR DESCRIPTION
Adds a callback that fires before navigation, receiving the destination URL and a proceed() function. Allows consumers to wrap the DOM update (e.g. for View Transitions) or cancel navigation.

EDIT: see https://github.com/preactjs/preact-iso/pull/137#discussion_r2982415600