### PR TITLE
Add back support

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Returns an object with the following properties:
   - `path: string` - The current path
   - `query: Record<string, string>` - The current query string parameters (`/profile?name=John` -> `{ name: 'John' }`)
   - `route: (url: string, replace?: boolean) => void` - A function to programmatically navigate to a new route. The `replace` param can optionally be used to overwrite history, navigating them away without keeping the current location in the history stack.
+  - `back: () => void` - A function to programmatically navigate back one entry in the browser history stack.
 
 ### `useRoute`
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Returns an object with the following properties:
   - `query: Record<string, string>` - The current query string parameters (`/profile?name=John` -> `{ name: 'John' }`)
   - `route: (url: string, replace?: boolean) => void` - A function to programmatically navigate to a new route. The `replace` param can optionally be used to overwrite history, navigating them away without keeping the current location in the history stack.
   - `back: () => void` - A function to programmatically navigate back one entry in the browser history stack.
+  - `forward: () => void` - A function to programmatically navigate forward one entry in the browser history stack.
 
 ### `useRoute`
 

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -43,6 +43,7 @@ interface LocationHook {
 	path: string;
 	query: Record<string, string>;
 	route: (url: string, replace?: boolean) => void;
+	back: () => void;
 }
 export const useLocation: () => LocationHook;
 

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -44,6 +44,7 @@ interface LocationHook {
 	query: Record<string, string>;
 	route: (url: string, replace?: boolean) => void;
 	back: () => void;
+	forward: () => void;
 }
 export const useLocation: () => LocationHook;
 

--- a/src/router.js
+++ b/src/router.js
@@ -116,6 +116,9 @@ export function LocationProvider(props) {
 			back: () => {
 				history.back();
 			},
+			forward: () => {
+				history.forward();
+			},
 			wasPush
 		};
 	}, [url]);

--- a/src/router.js
+++ b/src/router.js
@@ -61,6 +61,7 @@ function handleNav(state, action) {
 
 	if (push === true) history.pushState(null, '', url);
 	else if (push === false) history.replaceState(null, '', url);
+
 	return url;
 };
 
@@ -112,6 +113,9 @@ export function LocationProvider(props) {
 			path,
 			query: Object.fromEntries(u.searchParams),
 			route: (url, replace) => route({ url, replace }),
+			back: () => {
+				history.back();
+			},
 			wasPush
 		};
 	}, [url]);


### PR DESCRIPTION
Resolves #58 

I am pretty confused by this, it looks like web-test-runners headless browser does not support `history.back()` properly. When we call it, it will never fire a popstate event. I verified this feature working by using an html file and trying it out.

<details>
  <summary>The html file</summary>

```html
<!DOCTYPE html>
<html>
<head>
  <title>preact-iso back() test</title>
  <script type="importmap">
  {
    "imports": {
      "preact": "https://esm.sh/preact@10.25.4",
      "preact/hooks": "https://esm.sh/preact@10.25.4/hooks",
      "preact-iso/router": "./src/router.js"
    }
  }
  </script>
</head>
<body>
  <div id="app"></div>
  <script type="module">
    import { h, render } from 'preact';
    import { LocationProvider, Router, Route, useLocation } from 'preact-iso/router';

    function Nav() {
      const { url, path, back, route } = useLocation();
      return h('div', null,
        h('h2', null, `Current: url=${url} path=${path}`),
        h('nav', null,
          h('button', { onClick: () => route('/') }, 'Go /'), ' ',
          h('button', { onClick: () => route('/foo') }, 'Go /foo'), ' ',
          h('button', { onClick: () => route('/bar') }, 'Go /bar'), ' ',
          h('button', { id: 'back-btn', onClick: () => back() }, 'Back'),
        ),
      );
    }

    function Home() { return h('h1', null, 'Home /'); }
    function Foo() { return h('h1', null, 'Foo /foo'); }
    function Bar() { return h('h1', null, 'Bar /bar'); }
    function NotFound() { return h('h1', null, '404'); }

    function App() {
      return h(LocationProvider, null,
        h(Nav),
        h(Router, null,
          h(Route, { path: '/', component: Home }),
          h(Route, { path: '/foo', component: Foo }),
          h(Route, { path: '/bar', component: Bar }),
          h(Route, { default: true, component: NotFound }),
        ),
      );
    }

    render(h(App), document.getElementById('app'));
  </script>
</body>
</html>

```

</details>