### PR TITLE
fix: Mark module as not containing side effectful code

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"./prerender": "./src/prerender.js",
 		"./hydrate": "./src/hydrate.js"
 	},
+	"sideEffects": false,
 	"license": "MIT",
 	"description": "Isomorphic utilities for Preact",
 	"author": "The Preact Authors (https://preactjs.com)",


### PR DESCRIPTION
Reported here: https://bsky.app/profile/sdhfjksdf.bsky.social/post/3mi526vu74224

Can reproduce by creating a new preact project (`pn create preact`) with only prerendering enabled. Our option hook usage _is_ side-effectful, but is fairly safe to shake out when the user isn't consuming `lazy` or `<ErrorBoundary>`.

For the example case above, in which the user is only using `hydrate` (and technically `prerender`, but that's split into a separate bundle entirely), the bundle size changes as such:

| Before      | After |
| ----------- | ----------- |
| 20.46 kB │ gzip: 8.57 kB | 15.89 kB │ gzip: 6.81 kB |

---

I spent a while playing with this and I couldn't get it to break with Vite. This seems to only shake at the sub-file level, which is precisely what we want, so that the `_diff` & `_catchError` augments (for example) are kept when using `lazy` or `ErrorBoundary`. Everything from that file will be shaken if none of its exports are used, as they should be.