### PR TITLE
chore: add empty changeset for post-2.12.0 release work

### DIFF
--- a/.changeset/post-2-12-0-release-housekeeping.md
+++ b/.changeset/post-2-12-0-release-housekeeping.md
@@ -1,0 +1,4 @@
+---
+---
+Record the missing changeset entry for the post-2.12.0 release workflow migration.
+These follow-up commits were internal-only, so this should not trigger a package release.


### PR DESCRIPTION
- add the missing post-2.12.0 changeset record for the release workflow follow-up commits
- keep it empty so those internal-only changes do not trigger a package release
