### PR TITLE
feat(router): wrapNavigation + wrapUpdate hooks to animate navigations

### DIFF
--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -35,6 +35,13 @@ export function Router(props: {
 	onRouteChange?: (url: string) => void;
 	onLoadEnd?: (url: string) => void;
 	onLoadStart?: (url: string) => void;
+	/**
+	 * Wrap the commit that swaps in a suspending route's content once it has
+	 * loaded. Receives a `commit` callback that performs the swap; call it to
+	 * apply the route. Useful for animating navigations to async routes, e.g.
+	 * `wrapUpdate={commit => document.startViewTransition(commit)}`.
+	 */
+	wrapUpdate?: (commit: () => void) => void;
 	children?: NestedArray<VNode>;
 }): VNode;
 

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -1,7 +1,21 @@
 import { AnyComponent, ComponentChildren, Context, VNode } from 'preact';
 
 export const LocationProvider: {
-	(props: { scope?: string | RegExp; children?: ComponentChildren; }): VNode;
+	(props: {
+		scope?: string | RegExp;
+		/**
+		 * Wrap the commit of a navigation (the history update plus the state
+		 * change that drives the route re-render). Receives a `commit` callback;
+		 * call it to perform the navigation. Run it inside e.g.
+		 * `document.startViewTransition` so the browser captures the current route
+		 * as the transition's old snapshot before the new route swaps in:
+		 * `wrapNavigation={commit => document.startViewTransition(() => flushSync(commit))}`.
+		 * For navigations to async/suspending routes, pair with the Router's
+		 * `wrapUpdate` to resolve the transition once the content commits.
+		 */
+		wrapNavigation?: (commit: () => void) => void;
+		children?: ComponentChildren;
+	}): VNode;
 	ctx: Context<LocationHook>;
 };
 

--- a/src/router.js
+++ b/src/router.js
@@ -239,7 +239,16 @@ export function Router(props) {
 				}
 			}
 
-			RESOLVED.then(update);
+			// The route's content is ready to swap in. Let consumers wrap this
+			// commit (e.g. in document.startViewTransition) so navigations to
+			// async/suspending routes can be animated. The commit is internal
+			// to the Router, so without this hook there's no way to wrap the
+			// old-route -> new-content swap from the outside. `update` triggers
+			// a re-render; consumers that need it to happen synchronously inside
+			// their wrapper (the typical View Transition case) should flush it
+			// themselves, e.g. `wrapUpdate={commit => startViewTransition(() => flushSync(commit))}`.
+			if (props.wrapUpdate) RESOLVED.then(() => props.wrapUpdate(update));
+			else RESOLVED.then(update);
 		});
 	};
 

--- a/src/router.js
+++ b/src/router.js
@@ -24,16 +24,18 @@ function isInScope(href) {
 }
 
 /**
- * @param {string} state
+ * Resolve a navigation action to its target, or `null` if the action is not an
+ * in-scope navigation. Performs only the synchronous part of handling a link
+ * click (preventDefault); the history + state commit is left to the caller so
+ * it can be deferred / wrapped (e.g. in document.startViewTransition).
  * @param {MouseEvent | PopStateEvent | { url: string, replace?: boolean }} action
+ * @returns {{ url: string, push: boolean | undefined } | null}
  */
-function handleNav(state, action) {
-	let url = '';
-	push = undefined;
+function resolveNav(action) {
 	if (action && action.type === 'click') {
 		// ignore events the browser takes care of already:
 		if (action.ctrlKey || action.metaKey || action.altKey || action.shiftKey || action.button !== 0) {
-			return state;
+			return null;
 		}
 
 		const link = action.composedPath().find(el => el.nodeName == 'A' && el.href),
@@ -46,23 +48,18 @@ function handleNav(state, action) {
 			!isInScope(href) ||
 			link.download
 		) {
-			return state;
+			return null;
 		}
 
-		push = true;
 		action.preventDefault();
-		url = link.href.replace(location.origin, '');
+		return { url: link.href.replace(location.origin, ''), push: true };
 	} else if (action && action.url) {
-		push = !action.replace;
-		url = action.url;
-	} else {
-		url = location.pathname + location.search;
+		return { url: action.url, push: !action.replace };
 	}
 
-	if (push === true) history.pushState(null, '', url);
-	else if (push === false) history.replaceState(null, '', url);
-	return url;
-};
+	// popstate (or any other trigger): the browser already updated history.
+	return { url: location.pathname + location.search, push: undefined };
+}
 
 export const exec = (url, route, matches = {}) => {
 	url = url.split('/').filter(Boolean);
@@ -95,12 +92,34 @@ export const exec = (url, route, matches = {}) => {
 /**
  * @param {Object} props
  * @param {string | RegExp} [props.scope]
+ * @param {(commit: () => void) => void} [props.wrapNavigation]
  * @param {import('preact').ComponentChildren} [props.children]
  */
 export function LocationProvider(props) {
-	const [url, route] = useReducer(handleNav, location.pathname + location.search);
+	const [url, setUrl] = useReducer((_, next) => next, location.pathname + location.search);
 	if (props.scope) scope = props.scope;
 	const wasPush = push === true;
+
+	// Resolve + commit a navigation. The commit (history update + the state
+	// change that drives the route re-render) is handed to `wrapNavigation` when
+	// provided, so a consumer can run it inside e.g. document.startViewTransition
+	// — letting the browser capture the still-mounted old route as the
+	// transition's old snapshot before it swaps. Without the hook the commit runs
+	// immediately, identical to before. Kept in a ref so the once-registered
+	// listeners always invoke the latest props/closure.
+	const navigate = useRef();
+	navigate.current = (/** @type {any} */ action) => {
+		const next = resolveNav(action);
+		if (!next) return;
+		const commit = () => {
+			push = next.push;
+			if (push === true) history.pushState(null, '', next.url);
+			else if (push === false) history.replaceState(null, '', next.url);
+			setUrl(next.url);
+		};
+		if (props.wrapNavigation) props.wrapNavigation(commit);
+		else commit();
+	};
 
 	const value = useMemo(() => {
 		const u = new URL(url, location.origin);
@@ -110,18 +129,19 @@ export function LocationProvider(props) {
 			url,
 			path,
 			searchParams: Object.fromEntries(u.searchParams),
-			route: (url, replace) => route({ url, replace }),
+			route: (url, replace) => navigate.current({ url, replace }),
 			wasPush
 		};
 	}, [url]);
 
 	useLayoutEffect(() => {
-		addEventListener('click', route);
-		addEventListener('popstate', route);
+		const handler = (/** @type {MouseEvent | PopStateEvent} */ e) => navigate.current(e);
+		addEventListener('click', handler);
+		addEventListener('popstate', handler);
 
 		return () => {
-			removeEventListener('click', route);
-			removeEventListener('popstate', route);
+			removeEventListener('click', handler);
+			removeEventListener('popstate', handler);
 		};
 	}, []);
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -547,6 +547,58 @@ describe('Router', () => {
 		expect(loadEnd).not.to.have.been.called;
 	});
 
+	it('should route a suspending route\'s commit through wrapUpdate', async () => {
+		const A = sinon.fake(groggy(() => <h1>A</h1>, 1));
+		const B = sinon.fake(groggy(() => <h1>B</h1>, 1));
+		const wrapUpdate = sinon.fake(commit => commit());
+
+		render(
+			<ErrorBoundary>
+				<LocationProvider>
+					<Router wrapUpdate={wrapUpdate}>
+						<A path="/" />
+						<B path="/b" />
+					</Router>
+					<ShallowLocation />
+				</LocationProvider>
+			</ErrorBoundary>,
+			scratch
+		);
+
+		// Initial async route resolves: the commit is handed to wrapUpdate.
+		await sleep(10);
+		expect(scratch).to.have.property('innerHTML', '<h1>A</h1>');
+		expect(wrapUpdate).to.have.been.called;
+		expect(wrapUpdate.lastCall.args[0]).to.be.a('function');
+		wrapUpdate.resetHistory();
+
+		// Navigating to another async route funnels its commit through wrapUpdate
+		// too, and the content swaps in when the commit runs.
+		loc.route('/b');
+		await sleep(10);
+		expect(wrapUpdate).to.have.been.called;
+		expect(wrapUpdate.firstCall.args[0]).to.be.a('function');
+		expect(scratch).to.have.property('innerHTML', '<h1>B</h1>');
+	});
+
+	it('should still commit suspending routes when wrapUpdate is omitted', async () => {
+		const A = sinon.fake(groggy(() => <h1>A</h1>, 1));
+
+		render(
+			<ErrorBoundary>
+				<LocationProvider>
+					<Router>
+						<A path="/" />
+					</Router>
+				</LocationProvider>
+			</ErrorBoundary>,
+			scratch
+		);
+
+		await sleep(10);
+		expect(scratch).to.have.property('innerHTML', '<h1>A</h1>');
+	});
+
 	describe('intercepted VS external links', () => {
 		const shouldIntercept = [null, '', '_self', 'self', '_SELF'];
 		const shouldNavigate = ['_top', '_parent', '_blank', 'custom', '_BLANK'];

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -599,6 +599,91 @@ describe('Router', () => {
 		expect(scratch).to.have.property('innerHTML', '<h1>A</h1>');
 	});
 
+	it('should route navigations through wrapNavigation, with the old route still mounted until the commit runs', async () => {
+		const Home = () => <h1>Home</h1>;
+		const B = () => <h1>B</h1>;
+
+		let htmlAtWrap;
+		const wrapNavigation = sinon.fake(commit => {
+			// The old route is still on screen here — this is the window in which a
+			// consumer would start a view transition before swapping.
+			htmlAtWrap = scratch.innerHTML;
+			commit();
+		});
+
+		render(
+			<LocationProvider wrapNavigation={wrapNavigation}>
+				<Router>
+					<Home path="/" />
+					<B path="/b" />
+				</Router>
+				<ShallowLocation />
+			</LocationProvider>,
+			scratch
+		);
+
+		await sleep(1);
+		expect(scratch).to.have.property('innerHTML', '<h1>Home</h1>');
+		// The initial render is not a navigation.
+		expect(wrapNavigation).not.to.have.been.called;
+
+		loc.route('/b');
+		await sleep(1);
+		expect(wrapNavigation).to.have.been.calledOnce;
+		expect(wrapNavigation.lastCall.args[0]).to.be.a('function');
+		expect(htmlAtWrap).to.equal('<h1>Home</h1>');
+		expect(scratch).to.have.property('innerHTML', '<h1>B</h1>');
+	});
+
+	it('should route link-click navigations through wrapNavigation (and still preventDefault)', async () => {
+		const Home = () => <a href="/b">go</a>;
+		const B = () => <h1>B</h1>;
+		const wrapNavigation = sinon.fake(commit => commit());
+		const pushState = sinon.spy(history, 'pushState');
+
+		render(
+			<LocationProvider wrapNavigation={wrapNavigation}>
+				<Router>
+					<Home path="/" />
+					<B path="/b" />
+				</Router>
+				<ShallowLocation />
+			</LocationProvider>,
+			scratch
+		);
+		await sleep(1);
+
+		scratch.querySelector('a').click();
+		await sleep(1);
+
+		expect(wrapNavigation).to.have.been.calledOnce;
+		expect(loc).to.deep.include({ url: '/b' });
+		expect(pushState).to.have.been.calledWith(null, '', '/b');
+		expect(scratch).to.have.property('innerHTML', '<h1>B</h1>');
+		pushState.restore();
+	});
+
+	it('should navigate normally when wrapNavigation is omitted', async () => {
+		const Home = () => <h1>Home</h1>;
+		const B = () => <h1>B</h1>;
+
+		render(
+			<LocationProvider>
+				<Router>
+					<Home path="/" />
+					<B path="/b" />
+				</Router>
+				<ShallowLocation />
+			</LocationProvider>,
+			scratch
+		);
+		await sleep(1);
+
+		loc.route('/b');
+		await sleep(1);
+		expect(scratch).to.have.property('innerHTML', '<h1>B</h1>');
+	});
+
 	describe('intercepted VS external links', () => {
 		const shouldIntercept = [null, '', '_self', 'self', '_SELF'];
 		const shouldNavigate = ['_top', '_parent', '_blank', 'custom', '_BLANK'];


### PR DESCRIPTION
## Problem

Animating navigations with the View Transition API needs two things preact-iso doesn't currently expose:

1. **Capture the old route before it swaps.** `document.startViewTransition` must run *before* the navigation re-renders, so the browser snapshots the outgoing route (this is what makes shared-element morphs work). But link clicks / `popstate` / `route()` all go straight into the reducer and the swap happens in an async re-render — there's no point at which a consumer can wrap the navigation while the old route is still mounted.
2. **Wrap the async content commit.** For a route that suspends (lazy `import()` / async data), the destination's content is committed via an internal post-suspense update (`RESOLVED.then(update)`) with no hook around it, so the transition can't be resolved when the content is ready.

Together these mean navigations can't be animated old→new: warm routes have no capture point, and cold routes also have no commit hook.

## Change

Two small, optional, complementary hooks:

**`wrapNavigation` on `<LocationProvider>`** — wraps the commit of a navigation (the history update + the state change that drives the re-render). Split the reducer's `handleNav` into `resolveNav` (detection only, plus the synchronous `preventDefault` for link clicks) and a separately-invoked commit, so the commit can be deferred:

```jsx
<LocationProvider
  wrapNavigation={commit =>
    document.startViewTransition(() => flushSync(commit))}
>
```

The browser captures the current route as the old snapshot before `commit()` swaps in the new one. Covers clicks, `popstate`, and programmatic `route()`.

**`wrapUpdate` on `<Router>`** — wraps the post-suspense content commit, so a navigation to an async route can resolve its transition once the content lands:

```jsx
<Router wrapUpdate={commit => /* resolve the in-flight transition */ commit()}>
```

Used together: `wrapNavigation` starts the transition and runs the route change; for a suspending route the consumer awaits `wrapUpdate` before completing it.

## Backwards compatibility

Fully backward compatible. Both props are optional; with them omitted, `resolveNav` + immediate commit reproduces the previous reducer behavior exactly, and the Router's `else RESOLVED.then(update)` path is unchanged.

## Tests

`test/router.test.js`, full suite green (41 router + node + lazy):
- a suspending route's commit is routed through `wrapUpdate`, and content swaps in when the commit runs; omitting it still commits;
- programmatic and link-click navigations are routed through `wrapNavigation` with the **old route still mounted** when it's called (the capture window), and `preventDefault` still fires; omitting it navigates normally.

## Context / motivation

Surfaced building a view-transitions toolkit on top of preact-iso. With just `wrapUpdate`, async routes stopped throwing but still didn't morph, because the *old* element was already gone by the time any hook fired. `wrapNavigation` is the missing "navigation is starting" moment; the two hooks together make warm and cold navigations animate old→new.

Happy to adjust API/naming (prop vs. context, `wrapNavigation`/`wrapUpdate` vs. alternatives) — these are the smallest hooks that unblock animating navigations.
