### PR TITLE
ci: Fix changesets executable files issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # https://github.com/changesets/action/issues/523
+      - name: GitHub API only supports non-executable files and directories
+        run: git ls-files | while read -r file; do [ -x "$file" ] && chmod -x "$file" || true; done
+
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
@@ -77,6 +81,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      # https://github.com/changesets/action/issues/523
+      - name: GitHub API only supports non-executable files and directories
+        run: git ls-files | while read -r file; do [ -x "$file" ] && chmod -x "$file" || true; done
 
       # changesets/action skips `git config user.*` in github-api commit mode,
       # and checkout uses persist-credentials: false, so no identity is set.


### PR DESCRIPTION
[See CI failures](https://github.com/preactjs/preact-iso/actions/runs/29657444162/job/88114223260)

I don't really want to check these files in as non-executable, as they're meant to be, so it seems better to just make them non-executable when it comes to publishing via changesets